### PR TITLE
Add --prompt-names option for overriding org/node names

### DIFF
--- a/internal/core/firefly_config.go
+++ b/internal/core/firefly_config.go
@@ -162,10 +162,10 @@ func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
 			Path: "./frontend",
 		},
 		Node: &NodeConfig{
-			Name: fmt.Sprintf("node_%s", member.ID),
+			Name: member.NodeName,
 		},
 		Org: &OrgConfig{
-			Name:     fmt.Sprintf("org_%s", member.ID),
+			Name:     member.OrgName,
 			Identity: member.Address,
 		},
 		P2PFS: &PublicStorageConfig{

--- a/internal/stacks/firefly_identity.go
+++ b/internal/stacks/firefly_identity.go
@@ -28,10 +28,8 @@ func (s *StackManager) registerFireflyIdentities(verbose bool) error {
 	emptyObject := make(map[string]interface{})
 
 	for _, member := range s.Stack.Members {
-		orgName := fmt.Sprintf("org_%s", member.ID)
-		nodeName := fmt.Sprintf("node_%s", member.ID)
 		ffURL := fmt.Sprintf("http://127.0.0.1:%d/api/v1", member.ExposedFireflyPort)
-		s.Log.Info(fmt.Sprintf("registering %s and %s", orgName, nodeName))
+		s.Log.Info(fmt.Sprintf("registering org and node for member %s", member.ID))
 
 		registerOrgURL := fmt.Sprintf("%s/network/register/node/organization", ffURL)
 		err := core.RequestWithRetry(http.MethodPost, registerOrgURL, emptyObject, nil)
@@ -53,13 +51,13 @@ func (s *StackManager) registerFireflyIdentities(verbose bool) error {
 				return nil
 			}
 			for _, o := range orgs {
-				foundOrg = foundOrg || o.Name == orgName
+				foundOrg = foundOrg || o.Name == member.OrgName
 			}
 			if !foundOrg && retries > 0 {
 				time.Sleep(1 * time.Second)
 				retries--
 			} else if !foundOrg && retries == 0 {
-				return fmt.Errorf("timeout error waiting to register %s and %s", orgName, nodeName)
+				return fmt.Errorf("timeout error waiting to register member %s", member.ID)
 			}
 		}
 

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -67,6 +67,8 @@ type InitOptions struct {
 	DatabaseSelection  DatabaseSelection
 	Verbose            bool
 	ExternalProcesses  int
+	OrgNames           []string
+	NodeNames          []string
 	BlockchainProvider BlockchainProvider
 	TokensProvider     TokensProvider
 }
@@ -294,6 +296,8 @@ func createMember(id string, index int, options *InitOptions, external bool) *ty
 		ExposedIPFSGWPort:       serviceBase + 7,
 		ExposedTokensPort:       serviceBase + 8,
 		External:                external,
+		OrgName:                 options.OrgNames[index],
+		NodeName:                options.NodeNames[index],
 	}
 }
 

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -41,4 +41,6 @@ type Member struct {
 	ExposedUIPort           int    `json:"exposedUiPort,omitempty"`
 	ExposedTokensPort       int    `json:"exposedTokensPort,omitempty"`
 	External                bool   `json:"external,omitempty"`
+	OrgName                 string `json:"orgName,omitempty"`
+	NodeName                string `json:"nodeName,omitempty"`
 }


### PR DESCRIPTION
This supports interactive adding of names only. Could not come up with a clean way
to do non-interactively - may need a general override mechanism for config keys.

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>