### PR TITLE
Add retry for docker pull to deal with occasional errors from ghcr

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -48,6 +48,13 @@ func RunDockerCommand(workingDir string, showCommand bool, pipeStdout bool, comm
 	return runCommand(dockerCmd, showCommand, pipeStdout, command...)
 }
 
+func RunDockerComposeCommandWithRetry(workingDir string, showCommand bool, pipeStdout bool, command ...string) (err error) {
+	for i := 0; err != nil && i < 3; i++ {
+		err = RunDockerComposeCommand(workingDir, showCommand, pipeStdout, command...)
+	}
+	return err
+}
+
 func RunDockerComposeCommand(workingDir string, showCommand bool, pipeStdout bool, command ...string) error {
 	dockerCmd := exec.Command("docker-compose", command...)
 	dockerCmd.Dir = workingDir

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -360,6 +360,11 @@ func (s *StackManager) runStartupSequence(workingDir string, verbose bool, first
 	}
 
 	s.Log.Info("starting FireFly dependencies")
+
+	if err := docker.RunDockerComposeCommandWithRetry(workingDir, verbose, verbose, "pull"); err != nil {
+		return err
+	}
+
 	if err := docker.RunDockerComposeCommand(workingDir, verbose, verbose, "up", "-d"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Split `docker-compose pull` into a separate step with retries, as a simple way to address https://github.com/hyperledger/firefly/issues/244