### PR TITLE
Update goreleaser binary name. Remove Windows binary.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,15 +22,13 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     main: ./ff
+    binary: ff
 archives:
   - replacements:
       darwin: Darwin
       linux: Linux
-      windows: Windows
-      386: i386
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988 // indirect
 	golang.org/x/text v0.3.4 // indirect


### PR DESCRIPTION
The main thing here is to rename the binary to `ff` so it's consistent whether you manually download and use a compiled binary, or if you `go install` it