### PR TITLE
Support for Prometheus Metrics Aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 .vscode
 ff/ff
 dist/
+*.iml
+.idea/

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -185,6 +185,8 @@ func init() {
 	initCmd.Flags().StringVarP(&initOptions.FireFlyVersion, "release", "r", "latest", "Select the FireFly release version to use")
 	initCmd.Flags().StringVarP(&initOptions.ManifestPath, "manifest", "m", "", "Path to a manifest.json file containing the versions of each FireFly microservice to use. Overrides the --release flag.")
 	initCmd.Flags().BoolVar(&promptNames, "prompt-names", false, "Prompt for org and node names instead of using the defaults")
+	initCmd.Flags().BoolVar(&initOptions.PrometheusEnabled, "prometheus-enabled", false, "Enables Prometheus metrics exposition and aggregation to a shared Prometheus server")
+	initCmd.Flags().IntVar(&initOptions.PrometheusPort, "prometheus-port", 9090, "Port for the shared Prometheus server")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,6 +80,11 @@ This command will start a stack and run it in the background.
 		for _, member := range stackManager.Stack.Members {
 			fmt.Printf("Web UI for member '%v': http://127.0.0.1:%v/ui\n", member.ID, member.ExposedFireflyPort)
 		}
+
+		if stackManager.Stack.PrometheusEnabled {
+			fmt.Printf("Web UI for shared Prometheus: http://127.0.0.1:%v\n", stackManager.Stack.ExposedPrometheusPort)
+		}
+
 		fmt.Printf("\nTo see logs for your stack run:\n\n%s logs %s\n\n", rootCmd.Use, stackName)
 		return nil
 	},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,3 +26,4 @@ var StacksDir = filepath.Join(homeDir, ".firefly", "stacks")
 
 var IPFSImageName = "ipfs/go-ipfs"
 var PostgresImageName = "postgres"
+var PrometheusImageName = "prom/prometheus"

--- a/internal/core/firefly_config.go
+++ b/internal/core/firefly_config.go
@@ -37,13 +37,13 @@ type HttpServerConfig struct {
 }
 
 type AdminServerConfig struct {
-	HttpServerConfig
+	HttpServerConfig `yaml:",inline"`
 	Enabled   bool   `yaml:"enabled,omitempty"`
 	PreInit   bool   `yaml:"preinit,omitempty"`
 }
 
 type MetricsServerConfig struct {
-	HttpServerConfig
+	HttpServerConfig `yaml:",inline"`
 	Enabled bool `yaml:"enabled,omitempty"`
 	Path    string `yaml:"path,omitempty"`
 }

--- a/internal/core/firefly_config.go
+++ b/internal/core/firefly_config.go
@@ -38,14 +38,14 @@ type HttpServerConfig struct {
 
 type AdminServerConfig struct {
 	HttpServerConfig `yaml:",inline"`
-	Enabled   bool   `yaml:"enabled,omitempty"`
-	PreInit   bool   `yaml:"preinit,omitempty"`
+	Enabled          bool `yaml:"enabled,omitempty"`
+	PreInit          bool `yaml:"preinit,omitempty"`
 }
 
 type MetricsServerConfig struct {
 	HttpServerConfig `yaml:",inline"`
-	Enabled bool `yaml:"enabled,omitempty"`
-	Path    string `yaml:"path,omitempty"`
+	Enabled          bool   `yaml:"enabled,omitempty"`
+	Path             string `yaml:"path,omitempty"`
 }
 
 type BasicAuth struct {
@@ -176,8 +176,8 @@ func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
 				Address:   "0.0.0.0",
 				PublicURL: fmt.Sprintf("http://127.0.0.1:%d", member.ExposedFireflyAdminPort),
 			},
-			Enabled:   true,
-			PreInit:   true,
+			Enabled: true,
+			PreInit: true,
 		},
 		UI: &UIConfig{
 			Path: "./frontend",
@@ -211,7 +211,7 @@ func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
 				PublicURL: fmt.Sprintf("http://127.0.0.1:%d", member.ExposedFireflyMetricsPort),
 			},
 			Enabled: true,
-			Path: "/metrics",
+			Path:    "/metrics",
 		}
 	} else {
 		memberConfig.Metrics = &MetricsServerConfig{

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -159,10 +159,10 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 
 	if s.PrometheusEnabled {
 		compose.Services["prometheus"] = &Service{
-			Image: constants.PrometheusImageName,
+			Image:         constants.PrometheusImageName,
 			ContainerName: "prometheus",
-			Ports: 		[]string{fmt.Sprintf("%d:9090", s.ExposedPrometheusPort)},
-			Volumes:    []string{"prometheus_data:/prometheus","prometheus_config:/etc/prometheus"},
+			Ports:         []string{fmt.Sprintf("%d:9090", s.ExposedPrometheusPort)},
+			Volumes:       []string{"prometheus_data:/prometheus", "prometheus_config:/etc/prometheus"},
 			Logging:       StandardLogOptions,
 		}
 		compose.Volumes["prometheus_data"] = struct{}{}

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -99,10 +99,6 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				Logging: StandardLogOptions,
 			}
 
-			if s.PrometheusEnabled {
-				compose.Services["firefly_core_"+member.ID].Ports = append(compose.Services["firefly_core_"+member.ID].Ports, fmt.Sprintf("%d:%d", member.ExposedFireflyMetricsPort, member.ExposedFireflyMetricsPort))
-			}
-
 			compose.Volumes[fmt.Sprintf("firefly_core_%s", member.ID)] = struct{}{}
 		}
 		if s.Database == "postgres" {

--- a/internal/stacks/prometheus_config.go
+++ b/internal/stacks/prometheus_config.go
@@ -1,0 +1,49 @@
+package stacks
+
+import "fmt"
+
+type GlobalConfig struct {
+	ScrapeInterval string `yaml:"scrape_interval,omitempty"`
+	ScrapeTimeout string `yaml:"scrape_timeout,omitempty"`
+}
+
+type ScrapeConfig struct {
+	JobName string `yaml:"job_name,omitempty"`
+	MetricsPath string `yaml:"metrics_path,omitempty"`
+	StaticConfigs []*StaticConfig `yaml:"static_configs,omitempty"`
+}
+
+type StaticConfig struct {
+	Targets []string `yaml:"targets,omitempty"`
+}
+
+type PrometheusConfig struct {
+	Global *GlobalConfig  `yaml:"global,omitempty"`
+	ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
+}
+
+func (s *StackManager) GeneratePrometheusConfig() *PrometheusConfig {
+	config := &PrometheusConfig{
+		Global: &GlobalConfig{
+			ScrapeInterval: "5s",
+			ScrapeTimeout: "5s",
+		},
+		ScrapeConfigs: []*ScrapeConfig{
+			{
+				JobName: "fireflies",
+				MetricsPath: "/metrics",
+				StaticConfigs: []*StaticConfig{
+					{
+						Targets: []string{},
+					},
+				},
+			},
+		},
+	}
+
+	for i, member := range s.Stack.Members {
+		config.ScrapeConfigs[0].StaticConfigs[0].Targets = append(config.ScrapeConfigs[0].StaticConfigs[0].Targets, fmt.Sprintf("firefly_core_%d:%d", i, member.ExposedFireflyMetricsPort))
+	}
+
+	return config
+}

--- a/internal/stacks/prometheus_config.go
+++ b/internal/stacks/prometheus_config.go
@@ -4,12 +4,12 @@ import "fmt"
 
 type GlobalConfig struct {
 	ScrapeInterval string `yaml:"scrape_interval,omitempty"`
-	ScrapeTimeout string `yaml:"scrape_timeout,omitempty"`
+	ScrapeTimeout  string `yaml:"scrape_timeout,omitempty"`
 }
 
 type ScrapeConfig struct {
-	JobName string `yaml:"job_name,omitempty"`
-	MetricsPath string `yaml:"metrics_path,omitempty"`
+	JobName       string          `yaml:"job_name,omitempty"`
+	MetricsPath   string          `yaml:"metrics_path,omitempty"`
 	StaticConfigs []*StaticConfig `yaml:"static_configs,omitempty"`
 }
 
@@ -18,7 +18,7 @@ type StaticConfig struct {
 }
 
 type PrometheusConfig struct {
-	Global *GlobalConfig  `yaml:"global,omitempty"`
+	Global        *GlobalConfig   `yaml:"global,omitempty"`
 	ScrapeConfigs []*ScrapeConfig `yaml:"scrape_configs,omitempty"`
 }
 
@@ -26,11 +26,11 @@ func (s *StackManager) GeneratePrometheusConfig() *PrometheusConfig {
 	config := &PrometheusConfig{
 		Global: &GlobalConfig{
 			ScrapeInterval: "5s",
-			ScrapeTimeout: "5s",
+			ScrapeTimeout:  "5s",
 		},
 		ScrapeConfigs: []*ScrapeConfig{
 			{
-				JobName: "fireflies",
+				JobName:     "fireflies",
 				MetricsPath: "/metrics",
 				StaticConfigs: []*StaticConfig{
 					{

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -623,7 +623,9 @@ func (s *StackManager) runFirstTimeSetup(verbose bool, options *StartOptions) er
 	}
 
 	if s.Stack.PrometheusEnabled {
-		if err := docker.CopyFileToVolume("prometheus_config", path.Join(workingDir, "configs", "prometheus.yml"), "/prometheus.yml", verbose); err != nil {
+		s.Log.Info("copying prometheus.yml to prometheus_config")
+		volumeName := fmt.Sprintf("%s_prometheus_config", s.Stack.Name)
+		if err := docker.CopyFileToVolume(volumeName, path.Join(workingDir, "configs", "prometheus.yml"), "/prometheus.yml", verbose); err != nil {
 			return err
 		}
 	}

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -264,10 +264,6 @@ func (s *StackManager) ensureDirectories() error {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Join(dataDir, "prometheus_config"), 0755); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -78,7 +78,7 @@ type InitOptions struct {
 	FireFlyVersion     string
 	ManifestPath       string
 	PrometheusEnabled  bool
-	PrometheusPort int
+	PrometheusPort     int
 }
 
 func ListStacks() ([]string, error) {

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -25,6 +25,8 @@ type Stack struct {
 	BlockchainProvider    string           `json:"blockchainProvider"`
 	TokensProvider        string           `json:"tokensProvider"`
 	VersionManifest       *VersionManifest `json:"versionManifest,omitempty"`
+	PrometheusEnabled     bool             `json:"prometheusEnabled,omitempty"`
+	ExposedPrometheusPort int               `json:"exposedPrometheusPort,omitempty"`
 }
 
 type Member struct {
@@ -34,6 +36,7 @@ type Member struct {
 	PrivateKey              string `json:"privateKey,omitempty"`
 	ExposedFireflyPort      int    `json:"exposedFireflyPort,omitempty"`
 	ExposedFireflyAdminPort int    `json:"exposedFireflyAdminPort,omitempty"`
+	ExposedFireflyMetricsPort int `json:"exposedFireflyMetricsPort,omitempty"`
 	ExposedConnectorPort    int    `json:"exposedConnectorPort,omitempty"`
 	ExposedPostgresPort     int    `json:"exposedPostgresPort,omitempty"`
 	ExposedDataexchangePort int    `json:"exposedDataexchangePort,omitempty"`

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -26,25 +26,25 @@ type Stack struct {
 	TokensProvider        string           `json:"tokensProvider"`
 	VersionManifest       *VersionManifest `json:"versionManifest,omitempty"`
 	PrometheusEnabled     bool             `json:"prometheusEnabled,omitempty"`
-	ExposedPrometheusPort int               `json:"exposedPrometheusPort,omitempty"`
+	ExposedPrometheusPort int              `json:"exposedPrometheusPort,omitempty"`
 }
 
 type Member struct {
-	ID                      string `json:"id,omitempty"`
-	Index                   *int   `json:"index,omitempty"`
-	Address                 string `json:"address,omitempty"`
-	PrivateKey              string `json:"privateKey,omitempty"`
-	ExposedFireflyPort      int    `json:"exposedFireflyPort,omitempty"`
-	ExposedFireflyAdminPort int    `json:"exposedFireflyAdminPort,omitempty"`
-	ExposedFireflyMetricsPort int `json:"exposedFireflyMetricsPort,omitempty"`
-	ExposedConnectorPort    int    `json:"exposedConnectorPort,omitempty"`
-	ExposedPostgresPort     int    `json:"exposedPostgresPort,omitempty"`
-	ExposedDataexchangePort int    `json:"exposedDataexchangePort,omitempty"`
-	ExposedIPFSApiPort      int    `json:"exposedIPFSApiPort,omitempty"`
-	ExposedIPFSGWPort       int    `json:"exposedIPFSGWPort,omitempty"`
-	ExposedUIPort           int    `json:"exposedUiPort,omitempty"`
-	ExposedTokensPort       int    `json:"exposedTokensPort,omitempty"`
-	External                bool   `json:"external,omitempty"`
-	OrgName                 string `json:"orgName,omitempty"`
-	NodeName                string `json:"nodeName,omitempty"`
+	ID                        string `json:"id,omitempty"`
+	Index                     *int   `json:"index,omitempty"`
+	Address                   string `json:"address,omitempty"`
+	PrivateKey                string `json:"privateKey,omitempty"`
+	ExposedFireflyPort        int    `json:"exposedFireflyPort,omitempty"`
+	ExposedFireflyAdminPort   int    `json:"exposedFireflyAdminPort,omitempty"`
+	ExposedFireflyMetricsPort int    `json:"exposedFireflyMetricsPort,omitempty"`
+	ExposedConnectorPort      int    `json:"exposedConnectorPort,omitempty"`
+	ExposedPostgresPort       int    `json:"exposedPostgresPort,omitempty"`
+	ExposedDataexchangePort   int    `json:"exposedDataexchangePort,omitempty"`
+	ExposedIPFSApiPort        int    `json:"exposedIPFSApiPort,omitempty"`
+	ExposedIPFSGWPort         int    `json:"exposedIPFSGWPort,omitempty"`
+	ExposedUIPort             int    `json:"exposedUiPort,omitempty"`
+	ExposedTokensPort         int    `json:"exposedTokensPort,omitempty"`
+	External                  bool   `json:"external,omitempty"`
+	OrgName                   string `json:"orgName,omitempty"`
+	NodeName                  string `json:"nodeName,omitempty"`
 }


### PR DESCRIPTION
## Description

Closes #121

Adds support for optionally enabling the FireFly metrics server and including a Prometheus server container configured to scrape each FireFly's metrics.

For example, one can create a stack w/ Prometheus enabled (custom manifest used for latest FF image):

```bash
./ff/ff init --prometheus-enabled=true --manifest=${HOME}/github.com/kaleido-io/firefly-cli/manifest.json dev
```

results in:

<img width="1676" alt="Screen Shot 2021-11-21 at 8 47 04 PM" src="https://user-images.githubusercontent.com/11233384/142789560-56ee5c59-ee04-439a-8b40-9bd81f874baa.png">
