### PR TITLE
Fix payload for config endpoint

### DIFF
--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -721,9 +721,12 @@ func (s *StackManager) PrintStackInfo(verbose bool) error {
 
 func (s *StackManager) patchConfigAndRestartFireflyNodes(verbose bool) error {
 	for _, member := range s.Stack.Members {
+		configPayload := map[string]interface{}{
+			"preInit": false,
+		}
 		s.Log.Info(fmt.Sprintf("applying configuration changes to %s", member.ID))
 		configRecordUrl := fmt.Sprintf("http://localhost:%d/admin/api/v1/config/records/admin", member.ExposedFireflyAdminPort)
-		if err := core.RequestWithRetry("PUT", configRecordUrl, "{\"preInit\": false}", nil); err != nil && err != io.EOF {
+		if err := core.RequestWithRetry("PUT", configRecordUrl, configPayload, nil); err != nil && err != io.EOF {
 			return err
 		}
 		resetUrl := fmt.Sprintf("http://localhost:%d/admin/api/v1/config/reset", member.ExposedFireflyAdminPort)


### PR DESCRIPTION
Previously the CLI was posting a stringified JSON object to the config endpoint, rather than actual JSON, which caused FireFly to overwrite the entire admin section of the config. This meant that after FireFly re-applies the new config, it just reverts to the default config value for all the admin settings. It was trying to set all of `config.admin` to one big long string. This fix sends _actual JSON_ which allows FireFly to properly patch the config, rather than overwriting the entire section (with a nonsense string)