### PR TITLE
Remove deprecated tokens ETHCONNECT_IDENTITY param

### DIFF
--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -59,7 +59,6 @@ func (p *ERC1155Provider) GetDockerServiceDefinitions() []*docker.ServiceDefinit
 				Environment: map[string]string{
 					"ETHCONNECT_URL":      p.getEthconnectURL(member),
 					"ETHCONNECT_INSTANCE": "/contracts/erc1155",
-					"ETHCONNECT_IDENTITY": strings.TrimPrefix(member.Address, "0x"),
 					"AUTO_INIT":           "false",
 				},
 				DependsOn: map[string]map[string]string{


### PR DESCRIPTION
`ETHCONNECT_IDENTITY` was removed from tokens in this commit: https://github.com/hyperledger/firefly-tokens-erc1155/commit/ab737c7caef0b88050457e7e0dd528ce45cc1d57.

