### PR TITLE
[prom_img_name] adding stack name in front of prometheus container name

### DIFF
--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -156,7 +156,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 	if s.PrometheusEnabled {
 		compose.Services["prometheus"] = &Service{
 			Image:         constants.PrometheusImageName,
-			ContainerName: "prometheus",
+			ContainerName: fmt.Sprintf("%s_prometheus", s.Name),
 			Ports:         []string{fmt.Sprintf("%d:9090", s.ExposedPrometheusPort)},
 			Volumes:       []string{"prometheus_data:/prometheus", "prometheus_config:/etc/prometheus"},
 			Logging:       StandardLogOptions,


### PR DESCRIPTION
Adding the stack name in front of the prometheus container name. This allows multiple stacks to have prometheus enabled on the same machine