### PR TITLE
[pg-maxconns] adding maxconns to postgres config

### DIFF
--- a/internal/core/firefly_config.go
+++ b/internal/core/firefly_config.go
@@ -107,6 +107,7 @@ type DataExchangeConfig struct {
 
 type CommonDBConfig struct {
 	URL        string            `yaml:"url,omitempty"`
+	MaxConns   int               `yaml:"maxConns,omitempty"`
 	Migrations *MigrationsConfig `yaml:"migrations,omitempty"`
 }
 
@@ -236,7 +237,8 @@ func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
 		memberConfig.Database = &DatabaseConfig{
 			Type: "postgres",
 			PostgreSQL: &CommonDBConfig{
-				URL: getPostgresURL(member),
+				URL:      getPostgresURL(member),
+				MaxConns: 50,
 				Migrations: &MigrationsConfig{
 					Auto: true,
 				},


### PR DESCRIPTION
Helps solve `ERROR SQL query failed: pq: sorry, too many clients already` error seen in https://github.com/hyperledger/firefly/issues/380