### PR TITLE
[add-back-prom] adding back prometheus

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -185,6 +185,8 @@ func init() {
 	initCmd.Flags().StringVarP(&initOptions.FireFlyVersion, "release", "r", "latest", "Select the FireFly release version to use")
 	initCmd.Flags().StringVarP(&initOptions.ManifestPath, "manifest", "m", "", "Path to a manifest.json file containing the versions of each FireFly microservice to use. Overrides the --release flag.")
 	initCmd.Flags().BoolVar(&promptNames, "prompt-names", false, "Prompt for org and node names instead of using the defaults")
+	initCmd.Flags().BoolVar(&initOptions.PrometheusEnabled, "prometheus-enabled", false, "Enables Prometheus metrics exposition and aggregation to a shared Prometheus server")
+	initCmd.Flags().IntVar(&initOptions.PrometheusPort, "prometheus-port", 9090, "Port for the shared Prometheus server")
 
 	rootCmd.AddCommand(initCmd)
 }


### PR DESCRIPTION
The `--prometheus-enabled` flag was inadvertently removed from `cmd/init.go` in a previous merge. This is to add it back

Signed-off-by: David Echelberger <david.echelberger@kaleido.io>