### PR TITLE
Add --platform linux/amd64 to suppress Docker warnings

### DIFF
--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -72,12 +72,12 @@ func (p *FabricProvider) FirstTimeSetup() error {
 	}
 
 	// Run cryptogen to generate MSP
-	if err := docker.RunDockerCommand(blockchainDirectory, p.Verbose, p.Verbose, "run", "--rm", "-v", fmt.Sprintf("%s:/etc/template.yml", cryptogenYamlPath), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "cryptogen", "generate", "--config", "/etc/template.yml", "--output", "/etc/firefly/organizations"); err != nil {
+	if err := docker.RunDockerCommand(blockchainDirectory, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", "-v", fmt.Sprintf("%s:/etc/template.yml", cryptogenYamlPath), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "cryptogen", "generate", "--config", "/etc/template.yml", "--output", "/etc/firefly/organizations"); err != nil {
 		return err
 	}
 
 	// Generate genesis block
-	if err := docker.RunDockerCommand(blockchainDirectory, p.Verbose, p.Verbose, "run", "--rm", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")), "hyperledger/fabric-tools:2.3", "configtxgen", "-outputBlock", "/etc/firefly/firefly.block", "-profile", "SingleOrgApplicationGenesis", "-channelID", "firefly"); err != nil {
+	if err := docker.RunDockerCommand(blockchainDirectory, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")), "hyperledger/fabric-tools:2.3", "configtxgen", "-outputBlock", "/etc/firefly/firefly.block", "-profile", "SingleOrgApplicationGenesis", "-channelID", "firefly"); err != nil {
 		return err
 	}
 
@@ -215,14 +215,14 @@ func (p *FabricProvider) createChannel() error {
 	p.Log.Info("creating channel")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "osnadmin", "channel", "join", "--channelID", "firefly", "--config-block", "/etc/firefly/firefly.block", "-o", "fabric_orderer:7053", "--ca-file", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/ca.crt", "--client-cert", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/client.crt", "--client-key", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/client.key")
+	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "osnadmin", "channel", "join", "--channelID", "firefly", "--config-block", "/etc/firefly/firefly.block", "-o", "fabric_orderer:7053", "--ca-file", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/ca.crt", "--client-cert", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/client.crt", "--client-key", "/etc/firefly/organizations/ordererOrganizations/example.com/users/Admin@example.com/tls/client.key")
 }
 
 func (p *FabricProvider) joinChannel() error {
 	p.Log.Info("joining channel")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "hyperledger/fabric-tools:2.3", "peer", "channel", "join", "-b", "/etc/firefly/firefly.block")
+	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "hyperledger/fabric-tools:2.3", "peer", "channel", "join", "-b", "/etc/firefly/firefly.block")
 }
 
 func (p *FabricProvider) extractChaincode() error {
@@ -254,14 +254,14 @@ func (p *FabricProvider) installChaincode() error {
 	p.Log.Info("installing chaincode")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/contracts", path.Join(stackDir, "contracts")), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "install", "/contracts/firefly_fabric.tar.gz")
+	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/contracts", path.Join(stackDir, "contracts")), "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "install", "/contracts/firefly_fabric.tar.gz")
 }
 
 func (p *FabricProvider) queryInstalled() (*QueryInstalledResponse, error) {
 	p.Log.Info("querying installed chaincode")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	str, err := docker.RunDockerCommandBuffered(stackDir, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "queryinstalled", "--output", "json")
+	str, err := docker.RunDockerCommandBuffered(stackDir, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "queryinstalled", "--output", "json")
 	if err != nil {
 		return nil, err
 	}
@@ -277,14 +277,14 @@ func (p *FabricProvider) approveChaincode(packageId string) error {
 	p.Log.Info("approving chaincode")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "approveformyorg", "-o", "fabric_orderer:7050", "--ordererTLSHostnameOverride", "fabric_orderer", "--channelID", "firefly", "--name", "firefly", "--version", "1.0", "--package-id", packageId, "--sequence", "1", "--tls", "--cafile", "/etc/firefly/organizations/ordererOrganizations/example.com/orderers/fabric_orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem")
+	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "approveformyorg", "-o", "fabric_orderer:7050", "--ordererTLSHostnameOverride", "fabric_orderer", "--channelID", "firefly", "--name", "firefly", "--version", "1.0", "--package-id", packageId, "--sequence", "1", "--tls", "--cafile", "/etc/firefly/organizations/ordererOrganizations/example.com/orderers/fabric_orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem")
 }
 
 func (p *FabricProvider) commitChaincode() error {
 	p.Log.Info("committing chaincode")
 	stackDir := path.Join(constants.StacksDir, p.Stack.Name)
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.Stack.Name)
-	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "commit", "-o", "fabric_orderer:7050", "--ordererTLSHostnameOverride", "fabric_orderer", "--channelID", "firefly", "--name", "firefly", "--version", "1.0", "--sequence", "1", "--tls", "--cafile", "/etc/firefly/organizations/ordererOrganizations/example.com/orderers/fabric_orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem")
+	return docker.RunDockerCommand(stackDir, p.Verbose, p.Verbose, "run", "--platform", getDockerPlatform(), "--rm", fmt.Sprintf("--network=%s_default", p.Stack.Name), "-e", "CORE_PEER_ADDRESS=fabric_peer:7051", "-e", "CORE_PEER_TLS_ENABLED=true", "-e", "CORE_PEER_TLS_ROOTCERT_FILE=/etc/firefly/organizations/peerOrganizations/org1.example.com/peers/fabric_peer.org1.example.com/tls/ca.crt", "-e", "CORE_PEER_LOCALMSPID=Org1MSP", "-e", "CORE_PEER_MSPCONFIGPATH=/etc/firefly/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp", "-v", fmt.Sprintf("%s:/etc/firefly", volumeName), "hyperledger/fabric-tools:2.3", "peer", "lifecycle", "chaincode", "commit", "-o", "fabric_orderer:7050", "--ordererTLSHostnameOverride", "fabric_orderer", "--channelID", "firefly", "--name", "firefly", "--version", "1.0", "--sequence", "1", "--tls", "--cafile", "/etc/firefly/organizations/ordererOrganizations/example.com/orderers/fabric_orderer.example.com/msp/tlscacerts/tlsca.example.com-cert.pem")
 }
 
 func (p *FabricProvider) registerIdentities() error {
@@ -300,4 +300,9 @@ func (p *FabricProvider) registerIdentities() error {
 		}
 	}
 	return nil
+}
+
+// As of release 2.4, Hyperledger Fabric only publishes amd64 images, but no arm64 specific images
+func getDockerPlatform() string {
+	return "linux/amd64"
 }


### PR DESCRIPTION
arm64 machines such as Apple's m1 series can run linux/amd64 images via Docker Desktop's emulation, but will produce the following warning that causes some command JSON output parsing to fail:

WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Because Fabric so far only publishes linux/amd64 images, and they seem to work fine running under the emulation on m1 machines, we can simply force the platform to be linux/amd4 during docker run in order to suppress the warning