### PR TITLE
Fixes for running on arm64

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -24,6 +24,6 @@ import (
 var homeDir, _ = os.UserHomeDir()
 var StacksDir = filepath.Join(homeDir, ".firefly", "stacks")
 
-var IPFSImageName = "ipfs/go-ipfs"
+var IPFSImageName = "ipfs/go-ipfs:v0.10.0"
 var PostgresImageName = "postgres"
 var PrometheusImageName = "prom/prometheus"

--- a/internal/stacks/ipfs_config.go
+++ b/internal/stacks/ipfs_config.go
@@ -25,6 +25,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+var ipfsConfigBytes []byte
+
 func GenerateSwarmKey() string {
 	key := make([]byte, 32)
 	rand.Read(key)


### PR DESCRIPTION
This PR contains a couple of fixes to be able to run FireFly on 64 bit ARM based processors, like M1 Macs.

IPFS has been downgraded to 0.10.0 until https://github.com/ipfs/go-ipfs/issues/8645 is fixed

Go Ethereum has been upgraded to 1.10 as it provides native arm64 builds

Resolves https://github.com/hyperledger/firefly-cli/issues/136