### PR TITLE
Remove duplicate pull of token/blockchain docker images

### DIFF
--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -455,18 +455,6 @@ func (s *StackManager) PullStack(verbose bool, options *PullOptions) error {
 		images = append(images, constants.PostgresImageName)
 	}
 
-	// Iterate over all images used by the blockchain provider
-	for _, service := range s.blockchainProvider.GetDockerServiceDefinitions() {
-		images = append(images, service.Service.Image)
-	}
-
-	// Iterate over all images used by the tokens provider
-	for iTok, tp := range s.tokenProviders {
-		for _, service := range tp.GetDockerServiceDefinitions(iTok) {
-			images = append(images, service.Service.Image)
-		}
-	}
-
 	// Use docker to pull every image - retry on failure
 	for _, image := range images {
 		s.Log.Info(fmt.Sprintf("pulling '%s", image))


### PR DESCRIPTION
With the addition of Stack.VersionManifest, that manifest is now the de facto
source of all images for the stack. There is no need to iterate over the
plugins' Docker service definitions a second time (which are now also generated
from the same VersionManifest).

Fixes #119