### PR TITLE
Use fabconnect image version in manifest

### DIFF
--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -170,7 +170,7 @@ func (p *FabricProvider) getFabconnectServiceDefinitions(members []*types.Member
 		serviceDefinitions[i] = &docker.ServiceDefinition{
 			ServiceName: "fabconnect_" + member.ID,
 			Service: &docker.Service{
-				Image:         "ghcr.io/hyperledger/firefly-fabconnect:latest",
+				Image:         p.Stack.VersionManifest.Fabconnect.GetDockerImageString(),
 				ContainerName: fmt.Sprintf("%s_fabconnect_%s", p.Stack.Name, member.ID),
 				Command:       "-f /fabconnect/fabconnect.yaml",
 				DependsOn: map[string]map[string]string{


### PR DESCRIPTION
While investigating https://github.com/hyperledger/firefly/issues/537 I discovered that we weren't actually using the version of fabconnect listed in the manifest, and were always pulling latest still. This caused lots of inconsistencies depending on when someone pulled the stack and sometimes resulted in a broken stack.