### PR TITLE
Add memory warning with stacks of more than 3 members

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -108,6 +109,13 @@ var initCmd = &cobra.Command{
 
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", stackName, rootCmd.Use, stackName)
 		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", filepath.Join(constants.StacksDir, stackName, "docker-compose.yml"))
+
+		switch runtime.GOOS {
+		case "windows", "darwin":
+			if memberCount > 2 {
+				fmt.Printf("\u001b[33mNOTE: If your Docker Desktop configuration is set to the default memory configuration (2 GB), you may need to increase this value. It is recommended to allocate 1 GB per member of your FireFly network.\u001b[0m\n\n")
+			}
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
Resolves https://github.com/hyperledger/firefly-cli/issues/150

Unfortunately there does not appear any way to easily programmatically set the Docker VM to use more memory, and the default (2 GB) is pretty lows for running the number of processes required to run a FireFly stack.

When a stack with more than 2 members (1 GB per member) is initialized, this prints a warning noting that the default may need to be increased.

As a future enhancement, it would be nice if this warning was only printed if not enough RAM was allocated, but that would require knowing how much RAM the Docker VM currently has allocated. I couldn't find a quick way to do that yet.

Note: This is not an issue on Linux, because Docker doesn't run in a VM on Linux.