### PR TITLE
Add deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,90 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/firefly-cli/internal/docker"
+	"github.com/hyperledger/firefly-cli/internal/stacks"
+	"github.com/spf13/cobra"
+)
+
+// deployCmd represents the deploy command
+var deployCmd = &cobra.Command{
+	Use:   "deploy <stack_name> <filename>",
+	Short: "Deploy a compiled smart contract to the blockchain used by a FireFly stack",
+	Long:  `Deploy a compiled smart contract to the blockchain used by a FireFly stack`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if err := docker.CheckDockerConfig(); err != nil {
+			return err
+		}
+
+		stackManager := stacks.NewStackManager(logger)
+		if len(args) == 0 {
+			return fmt.Errorf("no stack specified")
+		}
+		stackName := args[0]
+		if len(args) < 2 {
+			return fmt.Errorf("no filename specified")
+		}
+		filename := args[1]
+
+		if exists, err := stacks.CheckExists(stackName); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("stack '%s' does not exist", stackName)
+		}
+
+		if err := stackManager.LoadStack(stackName, verbose); err != nil {
+			return err
+		}
+
+		contractNames, err := stackManager.GetContracts(filename)
+		if err != nil {
+			return err
+		}
+		if len(contractNames) < 1 {
+			return fmt.Errorf("no contracts found in file: '%s'", filename)
+		}
+		selectedContractName := contractNames[0]
+		if len(contractNames) > 1 {
+			selectedContractName, err = selectMenu("select the contract to deploy", contractNames)
+			fmt.Print("\n")
+			if err != nil {
+				return err
+			}
+		}
+
+		fmt.Printf("deploying %s... ", selectedContractName)
+		contractAddress, err := stackManager.DeployContract(filename, selectedContractName, 0)
+		if err != nil {
+			return err
+		}
+
+		fmt.Print("done\n\n")
+		fmt.Printf("contract address: %s\n", contractAddress)
+		fmt.Print("\n")
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -32,11 +33,7 @@ func prompt(promptText string, validate func(string) error) (string, error) {
 		} else {
 			str = strings.TrimSpace(str)
 			if err := validate(str); err != nil {
-				if fancyFeatures {
-					fmt.Printf("\u001b[31mError: %s\u001b[0m\n", err.Error())
-				} else {
-					fmt.Printf("Error: %s\n", err.Error())
-				}
+				printError(err)
 			} else {
 				return str, nil
 			}
@@ -58,5 +55,39 @@ func confirm(promptText string) error {
 				return fmt.Errorf("confirmation declined with response: '%s'", str)
 			}
 		}
+	}
+}
+
+func selectMenu(promptText string, options []string) (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("\n")
+		for i, option := range options {
+			fmt.Printf("  %v) %s\n", i+1, option)
+		}
+		fmt.Printf("\n%s: ", promptText)
+		if str, err := reader.ReadString('\n'); err != nil {
+			return "", err
+		} else {
+			str = strings.TrimSpace(str)
+			index, err := strconv.Atoi(str)
+			if err != nil {
+				printError(fmt.Errorf("'%s' is not a valid option", str))
+				continue
+			}
+			if index < 1 || index > len(options) {
+				printError(fmt.Errorf("'%s' is not a valid option", str))
+				continue
+			}
+			return options[index-1], nil
+		}
+	}
+}
+
+func printError(err error) {
+	if fancyFeatures {
+		fmt.Printf("\u001b[31mError: %s\u001b[0m\n", err.Error())
+	} else {
+		fmt.Printf("Error: %s\n", err.Error())
 	}
 }

--- a/internal/blockchain/blockchain_provider.go
+++ b/internal/blockchain/blockchain_provider.go
@@ -31,4 +31,6 @@ type IBlockchainProvider interface {
 	GetDockerServiceDefinitions() []*docker.ServiceDefinition
 	GetFireflyConfig(m *types.Member) (blockchainConfig *core.BlockchainConfig, coreConfig *core.OrgConfig)
 	Reset() error
+	GetContracts(filename string) ([]string, error)
+	DeployContract(filename, contractName string, member types.Member) (string, error)
 }

--- a/internal/blockchain/ethereum/besu/besu_provider.go
+++ b/internal/blockchain/ethereum/besu/besu_provider.go
@@ -128,7 +128,7 @@ func (p *BesuProvider) FirstTimeSetup() error {
 }
 
 func (p *BesuProvider) DeploySmartContracts() error {
-	return ethereum.DeployContracts(p.Stack, p.Log, p.Verbose)
+	return ethconnect.DeployContracts(p.Stack, p.Log, p.Verbose)
 }
 
 func (p *BesuProvider) PreStart() error {
@@ -285,6 +285,23 @@ func (p *BesuProvider) GetFireflyConfig(m *types.Member) (blockchainConfig *core
 		},
 	}
 	return
+}
+
+func (p *BesuProvider) GetContracts(filename string) ([]string, error) {
+	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	contractNames := make([]string, len(contracts.Contracts))
+	i := 0
+	for contractName := range contracts.Contracts {
+		contractNames[i] = contractName
+	}
+	return contractNames, err
+}
+
+func (p *BesuProvider) DeployContract(filename, contractName string, member types.Member) (string, error) {
+	return ethconnect.DeployCustomContract(p.getEthconnectURL(&member), member.Address, filename, contractName)
 }
 
 func (p *BesuProvider) getEthconnectURL(member *types.Member) string {

--- a/internal/blockchain/ethereum/contracts.go
+++ b/internal/blockchain/ethereum/contracts.go
@@ -18,59 +18,21 @@ package ethereum
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum/ethconnect"
 	"github.com/hyperledger/firefly-cli/internal/constants"
 	"github.com/hyperledger/firefly-cli/internal/docker"
-	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
-func DeployContracts(s *types.Stack, log log.Logger, verbose bool) error {
-	var containerName string
-	for _, member := range s.Members {
-		if !member.External {
-			containerName = fmt.Sprintf("%s_firefly_core_%s", s.Name, member.ID)
-			break
-		}
-	}
-	if containerName == "" {
-		return errors.New("unable to extract contracts from container - no valid firefly core containers found in stack")
-	}
-	log.Info("extracting smart contracts")
+type CompiledContracts struct {
+	Contracts map[string]*CompiledContract `json:"contracts"`
+}
 
-	if err := ExtractContracts(s.Name, containerName, "/firefly/contracts", verbose); err != nil {
-		return err
-	}
-
-	fireflyContract, err := ReadCompiledContract(filepath.Join(constants.StacksDir, s.Name, "contracts", "Firefly.json"))
-	if err != nil {
-		return err
-	}
-
-	var fireflyContractAddress string
-	for _, member := range s.Members {
-		if fireflyContractAddress == "" {
-			// TODO: version the registered name
-			log.Info(fmt.Sprintf("deploying firefly contract on '%s'", member.ID))
-			fireflyContractAddress, err = DeployContract(member, fireflyContract, "firefly", map[string]string{})
-			if err != nil {
-				return err
-			}
-		} else {
-			log.Info(fmt.Sprintf("registering firefly contract on '%s'", member.ID))
-			err = RegisterContract(member, fireflyContract, fireflyContractAddress, "firefly", map[string]string{})
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+type CompiledContract struct {
+	ABI      interface{} `json:"abi"`
+	Bytecode string      `json:"bin"`
 }
 
 func ReadCompiledContract(filePath string) (*types.Contract, error) {
@@ -83,35 +45,19 @@ func ReadCompiledContract(filePath string) (*types.Contract, error) {
 	return contract, nil
 }
 
+func ReadCombinedABIJSON(filePath string) (*CompiledContracts, error) {
+	d, _ := ioutil.ReadFile(filePath)
+	var contracts *CompiledContracts
+	err := json.Unmarshal(d, &contracts)
+	if err != nil {
+		return nil, err
+	}
+	return contracts, nil
+}
+
 func ExtractContracts(stackName string, containerName string, dirName string, verbose bool) error {
 	workingDir := filepath.Join(constants.StacksDir, stackName)
 	if err := docker.RunDockerCommand(workingDir, verbose, verbose, "cp", containerName+":"+dirName, workingDir); err != nil {
-		return err
-	}
-	return nil
-}
-
-func DeployContract(member *types.Member, contract *types.Contract, name string, args map[string]string) (string, error) {
-	ethconnectUrl := fmt.Sprintf("http://127.0.0.1:%v", member.ExposedConnectorPort)
-	abiResponse, err := ethconnect.PublishABI(ethconnectUrl, contract)
-	if err != nil {
-		return "", err
-	}
-	deployResponse, err := ethconnect.DeployContract(ethconnectUrl, abiResponse.ID, member.Address, args, name)
-	if err != nil {
-		return "", err
-	}
-	return deployResponse.ContractAddress, nil
-}
-
-func RegisterContract(member *types.Member, contract *types.Contract, contractAddress string, name string, args map[string]string) error {
-	ethconnectUrl := fmt.Sprintf("http://127.0.0.1:%v", member.ExposedConnectorPort)
-	abiResponse, err := ethconnect.PublishABI(ethconnectUrl, contract)
-	if err != nil {
-		return err
-	}
-	_, err = ethconnect.RegisterContract(ethconnectUrl, abiResponse.ID, contractAddress, member.Address, name, args)
-	if err != nil {
 		return err
 	}
 	return nil

--- a/internal/blockchain/ethereum/ethconnect/client.go
+++ b/internal/blockchain/ethereum/ethconnect/client.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,7 +18,10 @@ package ethconnect
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,8 +29,13 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 
+	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum"
+	"github.com/hyperledger/firefly-cli/internal/constants"
+	"github.com/hyperledger/firefly-cli/internal/core"
+	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
@@ -48,7 +56,51 @@ type RegisterResponseBody struct {
 	RegisteredAs string `json:"registeredAs,omitempty"`
 }
 
-func PublishABI(ethconnectUrl string, contract *types.Contract) (*PublishAbiResponseBody, error) {
+type CompiledContracts struct {
+	Contracts map[string]*CompiledContract `json:"contracts"`
+}
+
+type CompiledContract struct {
+	ABI      interface{} `json:"abi"`
+	Bytecode string      `json:"bin"`
+}
+
+type EthconnectMessageRequest struct {
+	Headers  EthconnectMessageHeaders `json:"headers,omitempty"`
+	To       string                   `json:"to"`
+	From     string                   `json:"from,omitempty"`
+	ABI      interface{}              `json:"abi,omitempty"`
+	Bytecode string                   `json:"compiled"`
+}
+
+type EthconnectMessageHeaders struct {
+	Type string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type EthconnectMessageResponse struct {
+	Sent bool   `json:"sent,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type EthconnectReply struct {
+	ID              string                  `json:"_id,omitempty"`
+	Headers         *EthconnectReplyHeaders `json:"headers,omitempty"`
+	ContractAddress string                  `json:"contractAddress,omitempty"`
+	ErrorCode       string                  `json:"errorCode,omitempty"`
+	ErrorMessage    string                  `json:"errorMessage,omitempty"`
+}
+
+type EthconnectReplyHeaders struct {
+	ID            string  `json:"id,omitempty"`
+	RequestID     string  `json:"requestId,omitempty"`
+	RequestOffset string  `json:"requestOffset,omitempty"`
+	TimeElapsed   float64 `json:"timeElapsed,omitempty"`
+	TimeReceived  string  `json:"timeReceived,omitempty"`
+	Type          string  `json:"type,omitempty"`
+}
+
+func publishABI(ethconnectUrl string, contract *types.Contract) (*PublishAbiResponseBody, error) {
 	u, err := url.Parse(ethconnectUrl)
 	if err != nil {
 		return nil, err
@@ -102,7 +154,7 @@ func PublishABI(ethconnectUrl string, contract *types.Contract) (*PublishAbiResp
 	return publishAbiResponse, nil
 }
 
-func DeployContract(ethconnectUrl string, abiId string, fromAddress string, params map[string]string, registeredName string) (*DeployContractResponseBody, error) {
+func deployContract(ethconnectUrl string, abiId string, fromAddress string, params map[string]string, registeredName string) (*DeployContractResponseBody, error) {
 	u, err := url.Parse(ethconnectUrl)
 	if err != nil {
 		return nil, err
@@ -144,7 +196,7 @@ func DeployContract(ethconnectUrl string, abiId string, fromAddress string, para
 	return deployContractResponse, nil
 }
 
-func RegisterContract(ethconnectUrl string, abiId string, contractAddress string, fromAddress string, registeredName string, params map[string]string) (*RegisterResponseBody, error) {
+func registerContract(ethconnectUrl string, abiId string, contractAddress string, fromAddress string, registeredName string, params map[string]string) (*RegisterResponseBody, error) {
 	u, err := url.Parse(ethconnectUrl)
 	if err != nil {
 		return nil, err
@@ -177,4 +229,130 @@ func RegisterContract(ethconnectUrl string, abiId string, contractAddress string
 	var registerResponseBody *RegisterResponseBody
 	json.Unmarshal(responseBody, &registerResponseBody)
 	return registerResponseBody, nil
+}
+
+// Deprecated
+func DeployContract(member *types.Member, contract *types.Contract, name string, args map[string]string) (string, error) {
+	ethconnectUrl := fmt.Sprintf("http://127.0.0.1:%v", member.ExposedConnectorPort)
+	abiResponse, err := publishABI(ethconnectUrl, contract)
+	if err != nil {
+		return "", err
+	}
+	deployResponse, err := deployContract(ethconnectUrl, abiResponse.ID, member.Address, args, name)
+	if err != nil {
+		return "", err
+	}
+	return deployResponse.ContractAddress, nil
+}
+
+// Deprecated
+func RegisterContract(member *types.Member, contract *types.Contract, contractAddress string, name string, args map[string]string) error {
+	ethconnectUrl := fmt.Sprintf("http://127.0.0.1:%v", member.ExposedConnectorPort)
+	abiResponse, err := publishABI(ethconnectUrl, contract)
+	if err != nil {
+		return err
+	}
+	_, err = registerContract(ethconnectUrl, abiResponse.ID, contractAddress, member.Address, name, args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Deprecated
+func DeployContracts(s *types.Stack, log log.Logger, verbose bool) error {
+	var containerName string
+	for _, member := range s.Members {
+		if !member.External {
+			containerName = fmt.Sprintf("%s_firefly_core_%s", s.Name, member.ID)
+			break
+		}
+	}
+	if containerName == "" {
+		return errors.New("unable to extract contracts from container - no valid firefly core containers found in stack")
+	}
+	log.Info("extracting smart contracts")
+
+	if err := ethereum.ExtractContracts(s.Name, containerName, "/firefly/contracts", verbose); err != nil {
+		return err
+	}
+
+	fireflyContract, err := ethereum.ReadCompiledContract(filepath.Join(constants.StacksDir, s.Name, "contracts", "Firefly.json"))
+	if err != nil {
+		return err
+	}
+
+	var fireflyContractAddress string
+	for _, member := range s.Members {
+		if fireflyContractAddress == "" {
+			// TODO: version the registered name
+			log.Info(fmt.Sprintf("deploying firefly contract on '%s'", member.ID))
+			fireflyContractAddress, err = DeployContract(member, fireflyContract, "firefly", map[string]string{})
+			if err != nil {
+				return err
+			}
+		} else {
+			log.Info(fmt.Sprintf("registering firefly contract on '%s'", member.ID))
+			err = RegisterContract(member, fireflyContract, fireflyContractAddress, "firefly", map[string]string{})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func DeployCustomContract(ethconnectUrl, fromAddress, filename, contractName string) (string, error) {
+	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	if err != nil {
+		return "", nil
+	}
+
+	contract := contracts.Contracts[contractName]
+
+	hexBytecode, err := hex.DecodeString(contract.Bytecode)
+	if err != nil {
+		return "", err
+	}
+	base64Bytecode := base64.StdEncoding.EncodeToString(hexBytecode)
+
+	requestBody := &EthconnectMessageRequest{
+		Headers: EthconnectMessageHeaders{
+			Type: "DeployContract",
+		},
+		From:     fromAddress,
+		ABI:      contract.ABI,
+		Bytecode: base64Bytecode,
+	}
+
+	ethconnectResponse := &EthconnectMessageResponse{}
+	if err := core.RequestWithRetry("POST", ethconnectUrl, requestBody, ethconnectResponse, false); err != nil {
+		return "", err
+	}
+	reply, err := getReply(ethconnectUrl, ethconnectResponse.ID)
+	if err != nil {
+		return "", err
+	}
+	if reply.Headers.Type != "TransactionSuccess" {
+		return "", fmt.Errorf(reply.ErrorMessage)
+	}
+
+	return reply.ContractAddress, nil
+}
+
+func getReply(ethconnectUrl, id string) (*EthconnectReply, error) {
+	u, err := url.Parse(ethconnectUrl)
+	if err != nil {
+		return nil, err
+	}
+	u, err = u.Parse(path.Join("replies", id))
+	if err != nil {
+		return nil, err
+	}
+	requestUrl := u.String()
+
+	reply := &EthconnectReply{}
+	err = core.RequestWithRetry("GET", requestUrl, nil, reply, false)
+	return reply, err
 }

--- a/internal/blockchain/ethereum/geth/geth_provider.go
+++ b/internal/blockchain/ethereum/geth/geth_provider.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -142,7 +142,7 @@ func (p *GethProvider) PostStart() error {
 }
 
 func (p *GethProvider) DeploySmartContracts() error {
-	return ethereum.DeployContracts(p.Stack, p.Log, p.Verbose)
+	return ethconnect.DeployContracts(p.Stack, p.Log, p.Verbose)
 }
 
 func (p *GethProvider) GetDockerServiceDefinitions() []*docker.ServiceDefinition {
@@ -193,6 +193,24 @@ func (p *GethProvider) GetFireflyConfig(m *types.Member) (blockchainConfig *core
 
 func (p *GethProvider) Reset() error {
 	return nil
+}
+
+func (p *GethProvider) GetContracts(filename string) ([]string, error) {
+	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	contractNames := make([]string, len(contracts.Contracts))
+	i := 0
+	for contractName := range contracts.Contracts {
+		contractNames[i] = contractName
+		i++
+	}
+	return contractNames, err
+}
+
+func (p *GethProvider) DeployContract(filename, contractName string, member types.Member) (string, error) {
+	return ethconnect.DeployCustomContract(fmt.Sprintf("http://127.0.0.1:%v", member.ExposedConnectorPort), member.Address, filename, contractName)
 }
 
 func (p *GethProvider) getEthconnectURL(member *types.Member) string {

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -302,6 +302,14 @@ func (p *FabricProvider) registerIdentities() error {
 	return nil
 }
 
+func (p *FabricProvider) GetContracts(filename string) ([]string, error) {
+	return []string{}, fmt.Errorf("deploying chaincode on a Fabric network is not supported yet")
+}
+
+func (p *FabricProvider) DeployContract(filename, contractName string, member types.Member) (string, error) {
+	return "", fmt.Errorf("deploying chaincode on a Fabric network is not supported yet")
+}
+
 // As of release 2.4, Hyperledger Fabric only publishes amd64 images, but no arm64 specific images
 func getDockerPlatform() string {
 	return "linux/amd64"

--- a/internal/core/http.go
+++ b/internal/core/http.go
@@ -26,12 +26,14 @@ import (
 	"time"
 )
 
-func RequestWithRetry(method, url string, body, result interface{}) (err error) {
+func RequestWithRetry(method, url string, body, result interface{}, logRetries bool) (err error) {
 	retries := 30
 	for {
 		if err := request(method, url, body, result); err != nil {
 			if retries > 0 {
-				fmt.Printf("%s - retrying request...", err.Error())
+				if logRetries {
+					fmt.Printf("%s - retrying request...", err.Error())
+				}
 				retries--
 				time.Sleep(1 * time.Second)
 			} else {

--- a/internal/stacks/firefly_identity.go
+++ b/internal/stacks/firefly_identity.go
@@ -31,13 +31,13 @@ func (s *StackManager) registerFireflyIdentities(verbose bool) error {
 		s.Log.Info(fmt.Sprintf("registering org and node for member %s", member.ID))
 
 		registerOrgURL := fmt.Sprintf("%s/network/organizations/self?confirm=true", ffURL)
-		err := core.RequestWithRetry(http.MethodPost, registerOrgURL, emptyObject, nil)
+		err := core.RequestWithRetry(http.MethodPost, registerOrgURL, emptyObject, nil, verbose)
 		if err != nil {
 			return err
 		}
 
 		registerNodeURL := fmt.Sprintf("%s/network/nodes/self?confirm=true", ffURL)
-		err = core.RequestWithRetry(http.MethodPost, registerNodeURL, emptyObject, nil)
+		err = core.RequestWithRetry(http.MethodPost, registerNodeURL, emptyObject, nil, verbose)
 		if err != nil {
 			return nil
 		}

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -743,11 +743,11 @@ func (s *StackManager) patchConfigAndRestartFireflyNodes(verbose bool) error {
 	for _, member := range s.Stack.Members {
 		s.Log.Info(fmt.Sprintf("applying configuration changes to %s", member.ID))
 		configRecordUrl := fmt.Sprintf("http://localhost:%d/admin/api/v1/config/records/admin.preInit", member.ExposedFireflyAdminPort)
-		if err := core.RequestWithRetry("PUT", configRecordUrl, "false", nil); err != nil && err != io.EOF {
+		if err := core.RequestWithRetry("PUT", configRecordUrl, "false", nil, verbose); err != nil && err != io.EOF {
 			return err
 		}
 		resetUrl := fmt.Sprintf("http://localhost:%d/admin/api/v1/config/reset", member.ExposedFireflyAdminPort)
-		if err := core.RequestWithRetry("POST", resetUrl, "{}", nil); err != nil {
+		if err := core.RequestWithRetry("POST", resetUrl, "{}", nil, verbose); err != nil {
 			return err
 		}
 	}
@@ -764,6 +764,14 @@ func (s *StackManager) StackHasRunBefore() (bool, error) {
 	} else {
 		return true, nil
 	}
+}
+
+func (s *StackManager) GetContracts(filename string) ([]string, error) {
+	return s.blockchainProvider.GetContracts(filename)
+}
+
+func (s *StackManager) DeployContract(filename, contractName string, memberIndex int) (string, error) {
+	return s.blockchainProvider.DeployContract(filename, contractName, *s.Stack.Members[memberIndex])
 }
 
 func (s *StackManager) getBlockchainProvider(verbose bool) blockchain.IBlockchainProvider {

--- a/internal/tokens/erc1155/contracts.go
+++ b/internal/tokens/erc1155/contracts.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum"
+	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum/ethconnect"
 	"github.com/hyperledger/firefly-cli/internal/constants"
 	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/pkg/types"
@@ -56,13 +57,13 @@ func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex in
 		if tokenContractAddress == "" {
 			// TODO: version the registered name
 			log.Info(fmt.Sprintf("deploying ERC1155 contract on '%s'", member.ID))
-			tokenContractAddress, err = ethereum.DeployContract(member, tokenContract, "erc1155", map[string]string{"uri": TOKEN_URI_PATTERN})
+			tokenContractAddress, err = ethconnect.DeployContract(member, tokenContract, "erc1155", map[string]string{"uri": TOKEN_URI_PATTERN})
 			if err != nil {
 				return err
 			}
 		} else {
 			log.Info(fmt.Sprintf("registering ERC1155 contract on '%s'", member.ID))
-			err = ethereum.RegisterContract(member, tokenContract, tokenContractAddress, "erc1155", map[string]string{"uri": TOKEN_URI_PATTERN})
+			err = ethconnect.RegisterContract(member, tokenContract, tokenContractAddress, "erc1155", map[string]string{"uri": TOKEN_URI_PATTERN})
 			if err != nil {
 				return err
 			}

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -39,7 +39,7 @@ func (p *ERC1155Provider) FirstTimeSetup(tokenIdx int) error {
 	for _, member := range p.Stack.Members {
 		p.Log.Info(fmt.Sprintf("initializing tokens on member %s", member.ID))
 		tokenInitUrl := fmt.Sprintf("http://localhost:%d/api/v1/init", member.ExposedTokensPorts[tokenIdx])
-		if err := core.RequestWithRetry("POST", tokenInitUrl, nil, nil); err != nil {
+		if err := core.RequestWithRetry("POST", tokenInitUrl, nil, nil, p.Verbose); err != nil {
 			return err
 		}
 	}

--- a/internal/tokens/erc20erc721/erc20_erc721_provider.go
+++ b/internal/tokens/erc20erc721/erc20_erc721_provider.go
@@ -39,7 +39,7 @@ func (p *ERC20ERC721Provider) FirstTimeSetup(tokenIdx int) error {
 	for _, member := range p.Stack.Members {
 		p.Log.Info(fmt.Sprintf("initializing tokens on member %s", member.ID))
 		tokenInitUrl := fmt.Sprintf("http://localhost:%d/api/v1/init", member.ExposedTokensPorts[tokenIdx])
-		if err := core.RequestWithRetry("POST", tokenInitUrl, nil, nil); err != nil {
+		if err := core.RequestWithRetry("POST", tokenInitUrl, nil, nil, p.Verbose); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR adds a `deploy` command which can be used by test and other automation tools to deploy pre-compiled contracts. The syntax of the command is `ff deploy <stack_name> <file_name>`. If there is more than one contract in the file, a prompt will appear asking which contract to deploy.

Resolves https://github.com/hyperledger/firefly-cli/issues/151