### PR TITLE
CLI includes FF sandbox

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -193,6 +193,7 @@ func init() {
 	initCmd.Flags().StringVarP(&initOptions.ManifestPath, "manifest", "m", "", "Path to a manifest.json file containing the versions of each FireFly microservice to use. Overrides the --release flag.")
 	initCmd.Flags().BoolVar(&promptNames, "prompt-names", false, "Prompt for org and node names instead of using the defaults")
 	initCmd.Flags().BoolVar(&initOptions.PrometheusEnabled, "prometheus-enabled", false, "Enables Prometheus metrics exposition and aggregation to a shared Prometheus server")
+	initCmd.Flags().BoolVar(&initOptions.SandboxEnabled, "sandbox-enabled", true, "Enables the FireFly Sandbox to be started with your FireFly stack")
 	initCmd.Flags().IntVar(&initOptions.PrometheusPort, "prometheus-port", 9090, "Port for the shared Prometheus server")
 	initCmd.Flags().StringVarP(&initOptions.ExtraCoreConfigPath, "core-config", "", "", "The path to a yaml file containing extra config for FireFly Core")
 	initCmd.Flags().StringVarP(&initOptions.ExtraEthconnectConfigPath, "ethconnect-config", "", "", "The path to a yaml file containing extra config for Ethconnect")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -80,6 +80,9 @@ This command will start a stack and run it in the background.
 		fmt.Print("\n\n")
 		for _, member := range stackManager.Stack.Members {
 			fmt.Printf("Web UI for member '%v': http://127.0.0.1:%v/ui\n", member.ID, member.ExposedFireflyPort)
+			if stackManager.Stack.SandboxEnabled {
+				fmt.Printf("Sandbox UI for member '%v': http://127.0.0.1:%v\n\n", member.ID, member.ExposedSandboxPort)
+			}
 		}
 
 		if stackManager.Stack.PrometheusEnabled {

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -152,6 +152,16 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 			Logging:       StandardLogOptions,
 		}
 		compose.Volumes[fmt.Sprintf("dataexchange_%s", member.ID)] = struct{}{}
+		if s.SandboxEnabled {
+			compose.Services["sandbox_"+member.ID] = &Service{
+				Image:         "ghcr.io/hyperledger/firefly-sandbox:latest",
+				ContainerName: fmt.Sprintf("%s_sandbox_%s", s.Name, member.ID),
+				Ports:         []string{fmt.Sprintf("%d:3001", member.ExposedSandboxPort)},
+				Environment: map[string]string{
+					"FF_ENDPOINT": fmt.Sprintf("http://firefly_core_%d:%d", *member.Index, member.ExposedFireflyPort),
+				},
+			}
+		}
 	}
 
 	if s.PrometheusEnabled {

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -97,6 +97,7 @@ func (s *StackManager) InitStack(stackName string, memberCount int, options *typ
 		StackDir:              filepath.Join(constants.StacksDir, stackName),
 		InitDir:               filepath.Join(constants.StacksDir, stackName, "init"),
 		RuntimeDir:            filepath.Join(constants.StacksDir, stackName, "runtime"),
+		SandboxEnabled:        options.SandboxEnabled,
 	}
 
 	if options.PrometheusEnabled {
@@ -409,6 +410,10 @@ func createMember(id string, index int, options *types.InitOptions, external boo
 		member.ExposedTokensPorts = append(member.ExposedTokensPorts, nextPort)
 		nextPort++
 	}
+	if options.SandboxEnabled {
+		member.ExposedSandboxPort = nextPort
+		nextPort++
+	}
 	return member
 }
 
@@ -575,6 +580,10 @@ func (s *StackManager) checkPortsAvailable() error {
 		ports = append(ports, member.ExposedPostgresPort)
 		ports = append(ports, member.ExposedUIPort)
 		ports = append(ports, member.ExposedTokensPorts...)
+
+		if s.Stack.SandboxEnabled {
+			ports = append(ports, member.ExposedSandboxPort)
+		}
 	}
 
 	if s.Stack.PrometheusEnabled {

--- a/pkg/types/manifest.go
+++ b/pkg/types/manifest.go
@@ -29,6 +29,7 @@ type VersionManifest struct {
 	DataExchange      *ManifestEntry `json:"dataexchange-https"`
 	TokensERC1155     *ManifestEntry `json:"tokens-erc1155"`
 	TokensERC20ERC721 *ManifestEntry `json:"tokens-erc20-erc721"`
+	Sandbox           *ManifestEntry `json:"sandbox"`
 }
 
 func (m *VersionManifest) Entries() []*ManifestEntry {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -42,6 +42,7 @@ type InitOptions struct {
 	ManifestPath              string
 	PrometheusEnabled         bool
 	PrometheusPort            int
+	SandboxEnabled            bool
 	ExtraCoreConfigPath       string
 	ExtraEthconnectConfigPath string
 	BlockPeriod               int

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -26,6 +26,7 @@ type Stack struct {
 	TokenProviders        TokenProviders   `json:"tokenProviders"`
 	VersionManifest       *VersionManifest `json:"versionManifest,omitempty"`
 	PrometheusEnabled     bool             `json:"prometheusEnabled,omitempty"`
+	SandboxEnabled        bool             `json:"sandboxEnabled,omitempty"`
 	ExposedPrometheusPort int              `json:"exposedPrometheusPort,omitempty"`
 	ContractAddress       string           `json:"contractAddress,omitempty"`
 	InitDir               string           `json:-`
@@ -47,6 +48,7 @@ type Member struct {
 	ExposedIPFSApiPort        int    `json:"exposedIPFSApiPort,omitempty"`
 	ExposedIPFSGWPort         int    `json:"exposedIPFSGWPort,omitempty"`
 	ExposedUIPort             int    `json:"exposedUiPort,omitempty"`
+	ExposedSandboxPort        int    `json:"exposedSandboxPort,omitempty"`
 	ExposedTokensPorts        []int  `json:"exposedTokensPorts,omitempty"`
 	External                  bool   `json:"external,omitempty"`
 	OrgName                   string `json:"orgName,omitempty"`


### PR DESCRIPTION
The CLI now starts up the FireFly sandbox by default. To remove this, use the `--sandbox-enabled` flag.