### PR TITLE
Pull stack images before first start, including Sandbox

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -27,3 +27,4 @@ var StacksDir = filepath.Join(homeDir, ".firefly", "stacks")
 var IPFSImageName = "ipfs/go-ipfs:v0.10.0"
 var PostgresImageName = "postgres"
 var PrometheusImageName = "prom/prometheus"
+var SandboxImageName = "ghcr.io/hyperledger/firefly-sandbox:latest"

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -154,7 +154,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 		compose.Volumes[fmt.Sprintf("dataexchange_%s", member.ID)] = struct{}{}
 		if s.SandboxEnabled {
 			compose.Services["sandbox_"+member.ID] = &Service{
-				Image:         "ghcr.io/hyperledger/firefly-sandbox:latest",
+				Image:         constants.SandboxImageName,
 				ContainerName: fmt.Sprintf("%s_sandbox_%s", s.Name, member.ID),
 				Ports:         []string{fmt.Sprintf("%d:3001", member.ExposedSandboxPort)},
 				Environment: map[string]string{

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -552,6 +552,11 @@ func (s *StackManager) PullStack(verbose bool, options *types.PullOptions) error
 		images = append(images, constants.PostgresImageName)
 	}
 
+	// Also pull the Sandbox if we're using it
+	if s.Stack.SandboxEnabled {
+		images = append(images, constants.SandboxImageName)
+	}
+
 	// Iterate over all images used by the blockchain provider
 	for _, service := range s.blockchainProvider.GetDockerServiceDefinitions() {
 		images = append(images, service.Service.Image)
@@ -751,6 +756,13 @@ func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptio
 	}
 
 	if err := s.copyDataExchangeConfigToVolumes(verbose); err != nil {
+		return err
+	}
+
+	pullOptions := &types.PullOptions{
+		Retries: 2,
+	}
+	if err := s.PullStack(verbose, pullOptions); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds the Sandbox to the list of images that get pulled as a part of the `PullStack` function.

Perhaps more controversially (though I can't recall why), this PR also adds `PullStack` to the `firstTimeSetup` function. @peterbroadhurst @awrichar can you think of any reason why this is not a good idea?