### PR TITLE
Make ERC-20 / ERC-721 default

### DIFF
--- a/cmd/deploy_ethereum.go
+++ b/cmd/deploy_ethereum.go
@@ -60,11 +60,11 @@ solc --combined-json abi,bin contract.sol > contract.json
 				return err
 			}
 		}
-		contractAddress, err := stackManager.DeployContract(filename, selectedContractName, 0, args[2:])
+		location, err := stackManager.DeployContract(filename, selectedContractName, 0, args[2:])
 		if err != nil {
 			return err
 		}
-		fmt.Print(contractAddress)
+		fmt.Print(location)
 		return nil
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -187,7 +187,7 @@ func init() {
 	initCmd.Flags().IntVarP(&initOptions.ServicesBasePort, "services-base-port", "s", 5100, "Mapped port base of services (100 added for each member)")
 	initCmd.Flags().StringVarP(&databaseSelection, "database", "d", "sqlite3", fmt.Sprintf("Database type to use. Options are: %v", types.DBSelectionStrings))
 	initCmd.Flags().StringVarP(&blockchainProviderInput, "blockchain-provider", "b", "geth", fmt.Sprintf("Blockchain provider to use. Options are: %v", types.BlockchainProviderStrings))
-	initCmd.Flags().StringArrayVarP(&tokenProvidersSelection, "token-providers", "t", []string{"erc1155"}, fmt.Sprintf("Token providers to use. Options are: %v", types.ValidTokenProviders))
+	initCmd.Flags().StringArrayVarP(&tokenProvidersSelection, "token-providers", "t", []string{"erc20_erc721"}, fmt.Sprintf("Token providers to use. Options are: %v", types.ValidTokenProviders))
 	initCmd.Flags().IntVarP(&initOptions.ExternalProcesses, "external", "e", 0, "Manage a number of FireFly core processes outside of the docker-compose stack - useful for development and debugging")
 	initCmd.Flags().StringVarP(&initOptions.FireFlyVersion, "release", "r", "latest", "Select the FireFly release version to use")
 	initCmd.Flags().StringVarP(&initOptions.ManifestPath, "manifest", "m", "", "Path to a manifest.json file containing the versions of each FireFly microservice to use. Overrides the --release flag.")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -71,13 +71,17 @@ This command will start a stack and run it in the background.
 		if spin != nil {
 			spin.Start()
 		}
-		if err := stackManager.StartStack(verbose, &startOptions); err != nil {
+		messages, err := stackManager.StartStack(verbose, &startOptions)
+		if err != nil {
 			return err
 		}
 		if spin != nil {
 			spin.Stop()
 		}
 		fmt.Print("\n\n")
+		for _, message := range messages {
+			fmt.Printf("%s\n\n", message)
+		}
 		for _, member := range stackManager.Stack.Members {
 			fmt.Printf("Web UI for member '%v': http://127.0.0.1:%v/ui\n", member.ID, member.ExposedFireflyPort)
 			if stackManager.Stack.SandboxEnabled {

--- a/internal/blockchain/blockchain_provider.go
+++ b/internal/blockchain/blockchain_provider.go
@@ -25,14 +25,14 @@ import (
 type IBlockchainProvider interface {
 	WriteConfig(options *types.InitOptions) error
 	FirstTimeSetup() error
-	DeployFireFlyContract() (*core.BlockchainConfig, error)
+	DeployFireFlyContract() (*core.BlockchainConfig, *types.ContractDeploymentResult, error)
 	PreStart() error
 	PostStart() error
 	GetDockerServiceDefinitions() []*docker.ServiceDefinition
 	GetFireflyConfig(stack *types.Stack, member *types.Member) (blockchainConfig *core.BlockchainConfig, coreConfig *core.OrgConfig)
 	Reset() error
 	GetContracts(filename string, extraArgs []string) ([]string, error)
-	DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (interface{}, error)
+	DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (*types.ContractDeploymentResult, error)
 	CreateAccount(args []string) (interface{}, error)
 	ParseAccount(interface{}) interface{}
 }

--- a/internal/blockchain/ethereum/besu/besu_provider.go
+++ b/internal/blockchain/ethereum/besu/besu_provider.go
@@ -223,7 +223,7 @@ func (p *BesuProvider) Reset() error {
 }
 
 func (p *BesuProvider) GetContracts(filename string, extraArgs []string) ([]string, error) {
-	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	contracts, err := ethereum.ReadContractJSON(filename)
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/blockchain/ethereum/besu/besu_provider.go
+++ b/internal/blockchain/ethereum/besu/besu_provider.go
@@ -144,7 +144,7 @@ func (p *BesuProvider) PostStart() error {
 	return nil
 }
 
-func (p *BesuProvider) DeployFireFlyContract() (*core.BlockchainConfig, error) {
+func (p *BesuProvider) DeployFireFlyContract() (*core.BlockchainConfig, *types.ContractDeploymentResult, error) {
 	return ethconnect.DeployFireFlyContract(p.Stack, p.Log, p.Verbose)
 }
 
@@ -236,14 +236,20 @@ func (p *BesuProvider) GetContracts(filename string, extraArgs []string) ([]stri
 	return contractNames, err
 }
 
-func (p *BesuProvider) DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (interface{}, error) {
+func (p *BesuProvider) DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (*types.ContractDeploymentResult, error) {
 	contractAddres, err := ethconnect.DeployCustomContract(member, filename, contractName)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]string{
-		"address": contractAddres,
-	}, nil
+	result := &types.ContractDeploymentResult{
+		DeployedContract: &types.DeployedContract{
+			Name: contractName,
+			Location: map[string]string{
+				"address": contractAddres,
+			},
+		},
+	}
+	return result, nil
 }
 
 func (p *BesuProvider) CreateAccount(args []string) (interface{}, error) {

--- a/internal/blockchain/ethereum/ethconnect/client.go
+++ b/internal/blockchain/ethereum/ethconnect/client.go
@@ -301,15 +301,17 @@ func DeployFireFlyContract(s *types.Stack, log log.Logger, verbose bool) (*core.
 		return nil, err
 	}
 
-	contracts, err := ethereum.ReadCombinedABIJSON(filepath.Join(s.RuntimeDir, "contracts", "Firefly.json"))
+	var fireflyContract *ethereum.CompiledContract
+	contracts, err := ethereum.ReadContractJSON(filepath.Join(s.RuntimeDir, "contracts", "Firefly.json"))
 	if err != nil {
 		return nil, err
 	}
+
 	fireflyContract, ok := contracts.Contracts["Firefly.sol:Firefly"]
 	if !ok {
-		fireflyContract, err = ethereum.ReadTruffleCompiledContract(filepath.Join(s.RuntimeDir, "contracts", "Firefly.json"))
-		if err != nil {
-			return nil, err
+		fireflyContract, ok = contracts.Contracts["Firefly"]
+		if !ok {
+			return nil, fmt.Errorf("unable to find compiled FireFly contract")
 		}
 	}
 
@@ -328,7 +330,7 @@ func DeployFireFlyContract(s *types.Stack, log log.Logger, verbose bool) (*core.
 }
 
 func DeployCustomContract(member *types.Member, filename, contractName string) (string, error) {
-	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	contracts, err := ethereum.ReadContractJSON(filename)
 	if err != nil {
 		return "", nil
 	}

--- a/internal/blockchain/ethereum/ethconnect/client.go
+++ b/internal/blockchain/ethereum/ethconnect/client.go
@@ -282,7 +282,7 @@ func DeprecatedRegisterContract(member *types.Member, contract *ethereum.Compile
 	return nil
 }
 
-func DeployFireFlyContract(s *types.Stack, log log.Logger, verbose bool) (*core.BlockchainConfig, error) {
+func DeployFireFlyContract(s *types.Stack, log log.Logger, verbose bool) (*core.BlockchainConfig, *types.ContractDeploymentResult, error) {
 	var containerName string
 	var firstNonExternalMember *types.Member
 	for _, member := range s.Members {
@@ -293,40 +293,47 @@ func DeployFireFlyContract(s *types.Stack, log log.Logger, verbose bool) (*core.
 		}
 	}
 	if containerName == "" {
-		return nil, errors.New("unable to extract contracts from container - no valid firefly core containers found in stack")
+		return nil, nil, errors.New("unable to extract contracts from container - no valid firefly core containers found in stack")
 	}
 	log.Info("extracting smart contracts")
 
 	if err := ethereum.ExtractContracts(containerName, "/firefly/contracts", s.RuntimeDir, verbose); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var fireflyContract *ethereum.CompiledContract
 	contracts, err := ethereum.ReadContractJSON(filepath.Join(s.RuntimeDir, "contracts", "Firefly.json"))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	fireflyContract, ok := contracts.Contracts["Firefly.sol:Firefly"]
 	if !ok {
-		fireflyContract, ok = contracts.Contracts["Firefly"]
+		fireflyContract, ok = contracts.Contracts["FireFly"]
 		if !ok {
-			return nil, fmt.Errorf("unable to find compiled FireFly contract")
+			return nil, nil, fmt.Errorf("unable to find compiled FireFly contract")
 		}
 	}
 
 	log.Info(fmt.Sprintf("deploying firefly contract via '%s'", firstNonExternalMember.ID))
 	contractAddress, err := deployContract(firstNonExternalMember, fireflyContract, map[string]string{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &core.BlockchainConfig{
+	blockchainConfig := &core.BlockchainConfig{
 		Ethereum: &core.EthereumConfig{
 			Ethconnect: &core.EthconnectConfig{
 				Instance: contractAddress,
 			},
 		},
-	}, nil
+	}
+	result := &types.ContractDeploymentResult{
+		DeployedContract: &types.DeployedContract{
+			Name:     "FireFly",
+			Location: map[string]string{"address": contractAddress},
+		},
+	}
+	return blockchainConfig, result, nil
 }
 
 func DeployCustomContract(member *types.Member, filename, contractName string) (string, error) {

--- a/internal/blockchain/ethereum/geth/geth_provider.go
+++ b/internal/blockchain/ethereum/geth/geth_provider.go
@@ -205,7 +205,7 @@ func (p *GethProvider) Reset() error {
 }
 
 func (p *GethProvider) GetContracts(filename string, extraArgs []string) ([]string, error) {
-	contracts, err := ethereum.ReadCombinedABIJSON(filename)
+	contracts, err := ethereum.ReadContractJSON(filename)
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/blockchain/ethereum/geth/geth_provider.go
+++ b/internal/blockchain/ethereum/geth/geth_provider.go
@@ -156,7 +156,7 @@ func (p *GethProvider) unlockAccount(address, password string) error {
 	return nil
 }
 
-func (p *GethProvider) DeployFireFlyContract() (*core.BlockchainConfig, error) {
+func (p *GethProvider) DeployFireFlyContract() (*core.BlockchainConfig, *types.ContractDeploymentResult, error) {
 	return ethconnect.DeployFireFlyContract(p.Stack, p.Log, p.Verbose)
 }
 
@@ -218,14 +218,21 @@ func (p *GethProvider) GetContracts(filename string, extraArgs []string) ([]stri
 	return contractNames, err
 }
 
-func (p *GethProvider) DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (interface{}, error) {
+func (p *GethProvider) DeployContract(filename, contractName string, member *types.Member, extraArgs []string) (*types.ContractDeploymentResult, error) {
 	contractAddres, err := ethconnect.DeployCustomContract(member, filename, contractName)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]string{
-		"address": contractAddres,
-	}, nil
+
+	result := &types.ContractDeploymentResult{
+		DeployedContract: &types.DeployedContract{
+			Name: contractName,
+			Location: map[string]string{
+				"address": contractAddres,
+			},
+		},
+	}
+	return result, nil
 }
 
 func (p *GethProvider) CreateAccount(args []string) (interface{}, error) {

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -775,8 +775,16 @@ func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptio
 	}
 
 	for i, tp := range s.tokenProviders {
-		if err := tp.DeploySmartContracts(i); err != nil {
+		result, err := tp.DeploySmartContracts(i)
+		if err != nil {
 			return err
+		}
+		if result != nil {
+			msg := result.GetTokenDeploymentMessage()
+			if msg != "" {
+				// TODO: move this to the end somehow
+				fmt.Println(msg)
+			}
 		}
 	}
 

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -316,7 +316,7 @@ func (s *StackManager) loadStackStateJSON() error {
 }
 
 func (s *StackManager) writeStackStateJSON(directory string) error {
-	stackStateBytes, err := json.MarshalIndent(s.Stack.State, "", " ")
+	stackStateBytes, err := json.MarshalIndent(s.Stack.State, "", "  ")
 	if err != nil {
 		return err
 	}
@@ -487,23 +487,24 @@ func createMember(id string, index int, options *types.InitOptions, external boo
 	return member
 }
 
-func (s *StackManager) StartStack(verbose bool, options *types.StartOptions) error {
+func (s *StackManager) StartStack(verbose bool, options *types.StartOptions) (messages []string, err error) {
 	fmt.Printf("starting FireFly stack '%s'... ", s.Stack.Name)
 	// Check to make sure all of our ports are available
-	err := s.checkPortsAvailable()
+	err = s.checkPortsAvailable()
 	if err != nil {
-		return err
+		return messages, err
 	}
 	hasBeenRun, err := s.StackHasRunBefore()
 	if err != nil {
-		return err
+		return messages, err
 	}
 	if !hasBeenRun {
-		err := s.runFirstTimeSetup(verbose, options)
+		setupMessages, err := s.runFirstTimeSetup(verbose, options)
+		messages = append(messages, setupMessages...)
 		if err != nil {
 			// Something bad happened during setup
 			if options.NoRollback {
-				return err
+				return messages, err
 			} else {
 				// Rollback changes
 				s.Log.Error(fmt.Errorf("an error occurred - rolling back changes"))
@@ -517,16 +518,16 @@ func (s *StackManager) StartStack(verbose bool, options *types.StartOptions) err
 					finalErr = fmt.Errorf("%s - all changes rolled back", err.Error())
 				}
 
-				return finalErr
+				return messages, finalErr
 			}
 		}
 	} else {
 		err = s.runStartupSequence(s.Stack.RuntimeDir, verbose, false)
 		if err != nil {
-			return err
+			return messages, err
 		}
 	}
-	return s.ensureFireflyNodesUp(true)
+	return messages, s.ensureFireflyNodesUp(true)
 }
 
 func (s *StackManager) PullStack(verbose bool, options *types.PullOptions) error {
@@ -729,7 +730,7 @@ func (s *StackManager) copyFireflyConfigToContainer(verbose bool, workingDir str
 	return nil
 }
 
-func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptions) (err error) {
+func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptions) (messages []string, err error) {
 	configDir := filepath.Join(s.Stack.RuntimeDir, "config")
 
 	for i := 0; i < len(s.Stack.Members); i++ {
@@ -739,60 +740,65 @@ func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptio
 	}
 
 	if err := copy.Copy(s.Stack.InitDir, s.Stack.RuntimeDir); err != nil {
-		return err
+		return messages, err
 	}
 
 	if err := s.disableFireflyCoreContainers(verbose, s.Stack.RuntimeDir); err != nil {
-		return err
+		return messages, err
 	}
 
 	s.Log.Info("initializing blockchain node")
 	if err := s.blockchainProvider.FirstTimeSetup(); err != nil {
-		return err
+		return messages, err
 	}
 
 	if s.Stack.PrometheusEnabled {
 		s.Log.Info("copying prometheus.yml to prometheus_config")
 		volumeName := fmt.Sprintf("%s_prometheus_config", s.Stack.Name)
 		if err := docker.CopyFileToVolume(volumeName, path.Join(configDir, "prometheus.yml"), "/prometheus.yml", verbose); err != nil {
-			return err
+			return messages, err
 		}
 	}
 
 	if err := s.copyDataExchangeConfigToVolumes(verbose); err != nil {
-		return err
+		return messages, err
 	}
 
 	pullOptions := &types.PullOptions{
 		Retries: 2,
 	}
 	if err := s.PullStack(verbose, pullOptions); err != nil {
-		return err
+		return messages, err
 	}
 
 	if err := s.runStartupSequence(s.Stack.RuntimeDir, verbose, true); err != nil {
-		return err
+		return messages, err
 	}
 
 	for i, tp := range s.tokenProviders {
 		result, err := tp.DeploySmartContracts(i)
 		if err != nil {
-			return err
+			return messages, err
 		}
 		if result != nil {
-			msg := result.GetTokenDeploymentMessage()
-			if msg != "" {
-				// TODO: move this to the end somehow
-				fmt.Println(msg)
+			if result.Message != "" {
+				messages = append(messages, result.Message)
 			}
+			s.Stack.State.DeployedContracts = append(s.Stack.State.DeployedContracts, result.DeployedContract)
 		}
 	}
 
 	if s.Stack.ContractAddress == "" {
 		s.Log.Info("deploying FireFly smart contracts")
-		blockchainConfig, err := s.blockchainProvider.DeployFireFlyContract()
+		blockchainConfig, result, err := s.blockchainProvider.DeployFireFlyContract()
 		if err != nil {
-			return err
+			return messages, err
+		}
+		if result != nil {
+			if result.Message != "" {
+				messages = append(messages, result.Message)
+			}
+			s.Stack.State.DeployedContracts = append(s.Stack.State.DeployedContracts, result.DeployedContract)
 		}
 		newConfig := &core.FireflyConfig{
 			Blockchain: blockchainConfig,
@@ -802,35 +808,35 @@ func (s *StackManager) runFirstTimeSetup(verbose bool, options *types.StartOptio
 
 	for _, member := range s.Stack.Members {
 		if err := s.copyFireflyConfigToContainer(verbose, configDir, member); err != nil {
-			return err
+			return messages, err
 		}
 	}
 
 	if err := s.enableFireflyCoreContainers(verbose, s.Stack.RuntimeDir); err != nil {
-		return err
+		return messages, err
 	}
 
 	// Bring up the FireFly Core containers now that we've finalized the runtime config
 	docker.RunDockerComposeCommand(s.Stack.InitDir, verbose, verbose, "-p", s.Stack.Name, "up", "-d")
 
 	if err := s.ensureFireflyNodesUp(true); err != nil {
-		return err
+		return messages, err
 	}
 
 	s.Log.Info("registering FireFly identities")
 	if err := s.registerFireflyIdentities(verbose); err != nil {
-		return err
+		return messages, err
 	}
 
 	s.Log.Info("initializing token providers")
 	for iTok, tp := range s.tokenProviders {
 		if err := tp.FirstTimeSetup(iTok); err != nil {
-			return err
+			return messages, err
 		}
 	}
 
 	// Update the stack state with any new state that was created as a part of the setup process
-	return s.writeStackStateJSON(s.Stack.RuntimeDir)
+	return messages, s.writeStackStateJSON(s.Stack.RuntimeDir)
 }
 
 func (s *StackManager) ensureFireflyNodesUp(firstTimeSetup bool) error {
@@ -1002,14 +1008,14 @@ func (s *StackManager) GetContracts(filename string, extraArgs []string) ([]stri
 }
 
 func (s *StackManager) DeployContract(filename, contractName string, memberIndex int, extraArgs []string) (string, error) {
-	contractLocation, err := s.blockchainProvider.DeployContract(filename, contractName, s.Stack.Members[memberIndex], extraArgs)
+	result, err := s.blockchainProvider.DeployContract(filename, contractName, s.Stack.Members[memberIndex], extraArgs)
 	if err != nil {
 		return "", err
 	}
 	// Update the stackState.json file with the newly deployed contract
 	deployedContract := &types.DeployedContract{
 		Name:     contractName,
-		Location: contractLocation,
+		Location: result.DeployedContract.Location,
 	}
 	s.Stack.State.DeployedContracts = append(s.Stack.State.DeployedContracts, deployedContract)
 	if err = s.writeStackStateJSON(s.Stack.RuntimeDir); err != nil {
@@ -1017,7 +1023,7 @@ func (s *StackManager) DeployContract(filename, contractName string, memberIndex
 	}
 
 	// Serialize the contract location to JSON to print on the command line
-	b, err := json.MarshalIndent(contractLocation, "", "  ")
+	b, err := json.MarshalIndent(result.DeployedContract.Location, "", "  ")
 	if err != nil {
 		return "", err
 	}

--- a/internal/tokens/erc1155/contracts.go
+++ b/internal/tokens/erc1155/contracts.go
@@ -24,26 +24,12 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum"
 	"github.com/hyperledger/firefly-cli/internal/blockchain/ethereum/ethconnect"
 	"github.com/hyperledger/firefly-cli/internal/log"
-	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
 const TOKEN_URI_PATTERN = "firefly://token/{id}"
 
-type TokenDeploymentResult struct {
-	Message string
-	Result  interface{}
-}
-
-func (t *TokenDeploymentResult) GetTokenDeploymentMessage() string {
-	return t.Message
-}
-
-func (t *TokenDeploymentResult) GetTokenDeploymentResult() interface{} {
-	return t.Result
-}
-
-func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex int) (tokens.ITokenDeploymentResult, error) {
+func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex int) (*types.ContractDeploymentResult, error) {
 	var containerName string
 	for _, member := range s.Members {
 		if !member.External {
@@ -87,8 +73,12 @@ func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex in
 		}
 	}
 
-	result := &TokenDeploymentResult{
-		Message: "i deployed an ERC1155 contract",
+	result := &types.ContractDeploymentResult{
+		Message: fmt.Sprintf("Deployed ERC-1155 contract to: %s", tokenContractAddress),
+		DeployedContract: &types.DeployedContract{
+			Name:     "erc1155",
+			Location: map[string]string{"address": tokenContractAddress},
+		},
 	}
 
 	return result, nil

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/core"
 	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
-	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
@@ -32,7 +31,7 @@ type ERC1155Provider struct {
 	Stack   *types.Stack
 }
 
-func (p *ERC1155Provider) DeploySmartContracts(tokenIndex int) (tokens.ITokenDeploymentResult, error) {
+func (p *ERC1155Provider) DeploySmartContracts(tokenIndex int) (*types.ContractDeploymentResult, error) {
 	return DeployContracts(p.Stack, p.Log, p.Verbose, tokenIndex)
 }
 

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/core"
 	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
+	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
@@ -31,7 +32,7 @@ type ERC1155Provider struct {
 	Stack   *types.Stack
 }
 
-func (p *ERC1155Provider) DeploySmartContracts(tokenIndex int) error {
+func (p *ERC1155Provider) DeploySmartContracts(tokenIndex int) (tokens.ITokenDeploymentResult, error) {
 	return DeployContracts(p.Stack, p.Log, p.Verbose, tokenIndex)
 }
 

--- a/internal/tokens/erc20erc721/contracts.go
+++ b/internal/tokens/erc20erc721/contracts.go
@@ -18,22 +18,67 @@ package erc20erc721
 
 import (
 	"github.com/hyperledger/firefly-cli/internal/log"
+	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
-func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex int) error {
+type TokenDeploymentResult struct {
+	Message string
+	Result  interface{}
+}
 
-	// Currently the act of creating and deploying a suitable ERC20 or ERC721 compliant
-	// contract, or contract factory, is an exercise left to the user.
-	//
-	// For users simply experimenting with how tokens work, the ERC1155 standard is recommended
-	// as a flexbile and fully formed sample implementation of fungible and non-fungible tokens
-	// with a set of features you would expect.
-	//
-	// For users looking to take the next step and create a "proper" coin or NFT collection,
-	// you really can't bypass the step of investigating the right OpenZeppelin (or other)
-	// base class and determining the tokenomics (around supply / minting / burning / governance)
-	// on top of that base class using the examples and standards out there.
+func (t *TokenDeploymentResult) GetTokenDeploymentMessage() string {
+	return t.Message
+}
 
-	return nil
+func (t *TokenDeploymentResult) GetTokenDeploymentResult() interface{} {
+	return t.Result
+}
+
+func DeployContracts(s *types.Stack, log log.Logger, verbose bool, tokenIndex int) (tokens.ITokenDeploymentResult, error) {
+	// var containerName string
+	// for _, member := range s.Members {
+	// 	if !member.External {
+	// 		containerName = fmt.Sprintf("%s_tokens_%s_%d", s.Name, member.ID, tokenIndex)
+	// 		break
+	// 	}
+	// }
+	// if containerName == "" {
+	// 	return nil, errors.New("unable to extract contracts from container - no valid tokens containers found in stack")
+	// }
+	// log.Info("extracting smart contracts")
+
+	// if err := ethereum.ExtractContracts(containerName, "/root/contracts", s.RuntimeDir, verbose); err != nil {
+	// 	return nil, err
+	// }
+
+	// tokenContract, err := ethereum.ReadSolcCompiledContract(filepath.Join(s.RuntimeDir, "contracts", "TokenFactory.json"))
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// var tokenContractAddress string
+	// for _, member := range s.Members {
+	// 	// TODO: move to address based contract deployment, once ERC-1155 connector is updated to not require an EthConnect REST API registration
+	// 	if tokenContractAddress == "" {
+	// 		log.Info(fmt.Sprintf("deploying ERC1155 contract on '%s'", member.ID))
+	// 		tokenContractAddress, err = ethconnect.DeprecatedDeployContract(member, tokenContract, "ERC20WithData", map[string]string{"uri": TOKEN_URI_PATTERN})
+	// 		if err != nil {
+	// 			return nil, err
+	// 		}
+	// 	} else {
+	// 		log.Info(fmt.Sprintf("registering ERC1155 contract on '%s'", member.ID))
+	// 		err = ethconnect.DeprecatedRegisterContract(member, tokenContract, tokenContractAddress, "erc1155", map[string]string{"uri": TOKEN_URI_PATTERN})
+	// 		if err != nil {
+	// 			return nil, err
+	// 		}
+	// 	}
+	// }
+
+	// deploymentResult := &TokenDeploymentResult{
+	// 	Message: "hey, I deployed a contract!",
+	// }
+
+	// return deploymentResult, nil
+	return nil, nil
 }

--- a/internal/tokens/erc20erc721/erc20_erc721_provider.go
+++ b/internal/tokens/erc20erc721/erc20_erc721_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/core"
 	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
+	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
@@ -31,7 +32,7 @@ type ERC20ERC721Provider struct {
 	Stack   *types.Stack
 }
 
-func (p *ERC20ERC721Provider) DeploySmartContracts(tokenIndex int) error {
+func (p *ERC20ERC721Provider) DeploySmartContracts(tokenIndex int) (tokens.ITokenDeploymentResult, error) {
 	return DeployContracts(p.Stack, p.Log, p.Verbose, tokenIndex)
 }
 

--- a/internal/tokens/erc20erc721/erc20_erc721_provider.go
+++ b/internal/tokens/erc20erc721/erc20_erc721_provider.go
@@ -22,7 +22,6 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/core"
 	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
-	"github.com/hyperledger/firefly-cli/internal/tokens"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
@@ -32,7 +31,7 @@ type ERC20ERC721Provider struct {
 	Stack   *types.Stack
 }
 
-func (p *ERC20ERC721Provider) DeploySmartContracts(tokenIndex int) (tokens.ITokenDeploymentResult, error) {
+func (p *ERC20ERC721Provider) DeploySmartContracts(tokenIndex int) (*types.ContractDeploymentResult, error) {
 	return DeployContracts(p.Stack, p.Log, p.Verbose, tokenIndex)
 }
 

--- a/internal/tokens/tokens_provider.go
+++ b/internal/tokens/tokens_provider.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ITokensProvider interface {
-	DeploySmartContracts(tokenIndex int) (ITokenDeploymentResult, error)
+	DeploySmartContracts(tokenIndex int) (*types.ContractDeploymentResult, error)
 	FirstTimeSetup(tokenIdx int) error
 	GetDockerServiceDefinitions(tokenIdx int) []*docker.ServiceDefinition
 	GetFireflyConfig(m *types.Member, tokenIdx int) *core.TokenConnector

--- a/internal/tokens/types.go
+++ b/internal/tokens/types.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -16,15 +16,7 @@
 
 package tokens
 
-import (
-	"github.com/hyperledger/firefly-cli/internal/core"
-	"github.com/hyperledger/firefly-cli/internal/docker"
-	"github.com/hyperledger/firefly-cli/pkg/types"
-)
-
-type ITokensProvider interface {
-	DeploySmartContracts(tokenIndex int) (ITokenDeploymentResult, error)
-	FirstTimeSetup(tokenIdx int) error
-	GetDockerServiceDefinitions(tokenIdx int) []*docker.ServiceDefinition
-	GetFireflyConfig(m *types.Member, tokenIdx int) *core.TokenConnector
+type ITokenDeploymentResult interface {
+	GetTokenDeploymentMessage() string
+	GetTokenDeploymentResult() interface{}
 }

--- a/pkg/types/contracts.go
+++ b/pkg/types/contracts.go
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tokens
+package types
 
-type ITokenDeploymentResult interface {
-	GetTokenDeploymentMessage() string
-	GetTokenDeploymentResult() interface{}
+type ContractDeploymentResult struct {
+	Message          string
+	DeployedContract *DeployedContract
 }


### PR DESCRIPTION
This PR makes the ERC-20 / ERC-721 token connector the default. It also deploys the newly packaged TokenFactory contract (in FireFly v1.0.0-rc.6) to streamline the process for users being able to experiment with tokens with external wallets like Metamask.