### PR TITLE
SPI updates for new alpha

### DIFF
--- a/internal/blockchain/ethereum/ethsigner/ethsigner.go
+++ b/internal/blockchain/ethereum/ethsigner/ethsigner.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hyperledger/firefly-cli/pkg/types"
 )
 
-var ethsignerImage = "ghcr.io/hyperledger/firefly-signer:v0.9.1"
+var ethsignerImage = "ghcr.io/hyperledger/firefly-signer:v0.9.6"
 
 // TODO: Probably randomize this and make it different per member?
 var keyPassword = "correcthorsebatterystaple"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -30,4 +30,4 @@ var PostgresImageName = "postgres"
 var PrometheusImageName = "prom/prometheus"
 var SandboxImageName = "ghcr.io/hyperledger/firefly-sandbox:latest"
 
-var FFTMImageName = "ghcr.io/hyperledger/firefly-transaction-manager:v0.9.0"
+var FFTMImageName = "ghcr.io/hyperledger/firefly-transaction-manager:v0.9.2"

--- a/internal/core/firefly_config.go
+++ b/internal/core/firefly_config.go
@@ -42,6 +42,11 @@ type AdminServerConfig struct {
 	PreInit          bool `yaml:"preinit,omitempty"`
 }
 
+type SPIServerConfig struct {
+	HttpServerConfig `yaml:",inline"`
+	Enabled          bool `yaml:"enabled,omitempty"`
+}
+
 type MetricsServerConfig struct {
 	HttpServerConfig `yaml:",inline"`
 	Enabled          bool   `yaml:"enabled,omitempty"`
@@ -156,7 +161,8 @@ type FireflyConfig struct {
 	Log          *LogConfig           `yaml:"log,omitempty"`
 	Debug        *HttpServerConfig    `yaml:"debug,omitempty"`
 	HTTP         *HttpServerConfig    `yaml:"http,omitempty"`
-	Admin        *AdminServerConfig   `yaml:"admin,omitempty"`
+	Admin        *AdminServerConfig   `yaml:"admin,omitempty"` // V1.0 admin API
+	SPI          *SPIServerConfig     `yaml:"spi,omitempty"`   // V1.1 and later SPI
 	Metrics      *MetricsServerConfig `yaml:"metrics,omitempty"`
 	UI           *UIConfig            `yaml:"ui,omitempty"`
 	Node         *NodeConfig          `yaml:"node,omitempty"`
@@ -170,6 +176,11 @@ type FireflyConfig struct {
 }
 
 func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
+	spiHttpConfig := HttpServerConfig{
+		Port:      member.ExposedFireflyAdminSPIPort,
+		Address:   "0.0.0.0",
+		PublicURL: fmt.Sprintf("http://127.0.0.1:%d", member.ExposedFireflyAdminSPIPort),
+	}
 	memberConfig := &FireflyConfig{
 		Log: &LogConfig{
 			Level: "debug",
@@ -183,12 +194,12 @@ func NewFireflyConfig(stack *types.Stack, member *types.Member) *FireflyConfig {
 			PublicURL: fmt.Sprintf("http://127.0.0.1:%d", member.ExposedFireflyPort),
 		},
 		Admin: &AdminServerConfig{
-			HttpServerConfig: HttpServerConfig{
-				Port:      member.ExposedFireflyAdminPort,
-				Address:   "0.0.0.0",
-				PublicURL: fmt.Sprintf("http://127.0.0.1:%d", member.ExposedFireflyAdminPort),
-			},
-			Enabled: true,
+			HttpServerConfig: spiHttpConfig,
+			Enabled:          true,
+		},
+		SPI: &SPIServerConfig{
+			HttpServerConfig: spiHttpConfig,
+			Enabled:          true,
 		},
 		UI: &UIConfig{
 			Path: "./frontend",

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -91,7 +91,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				ContainerName: fmt.Sprintf("%s_firefly_core_%s", s.Name, member.ID),
 				Ports: []string{
 					fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
-					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminPort, member.ExposedFireflyAdminPort),
+					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminSPIPort, member.ExposedFireflyAdminSPIPort),
 				},
 				Volumes: []string{fmt.Sprintf("firefly_core_%s:/etc/firefly", member.ID)},
 				DependsOn: map[string]map[string]string{

--- a/internal/stacks/fftm_config.go
+++ b/internal/stacks/fftm_config.go
@@ -88,7 +88,7 @@ func NewFFTMConfig(stack *types.Stack, member *types.Member) *FFTMConfig {
 			Port:    5008,
 		},
 		FFCore: FFTMFFCoreConfig{
-			URL: fmt.Sprintf("http://firefly_core_%s:%d", member.ID, member.ExposedFireflyAdminPort),
+			URL: fmt.Sprintf("http://firefly_core_%s:%d", member.ID, member.ExposedFireflyAdminSPIPort),
 		},
 		Connector: FFTMConnectorConfig{
 			URL:     fmt.Sprintf("http://ethconnect_%s:8080", member.ID),

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -489,19 +489,19 @@ func (s *StackManager) copyDataExchangeConfigToVolumes(verbose bool) error {
 func (s *StackManager) createMember(id string, index int, options *types.InitOptions, external bool) (*types.Member, error) {
 	serviceBase := options.ServicesBasePort + (index * 100)
 	member := &types.Member{
-		ID:                      id,
-		Index:                   &index,
-		ExposedFireflyPort:      options.FireFlyBasePort + index,
-		ExposedFireflyAdminPort: serviceBase + 1, // note shared blockchain node is on zero
-		ExposedConnectorPort:    serviceBase + 2,
-		ExposedUIPort:           serviceBase + 3,
-		ExposedDatabasePort:     serviceBase + 4,
-		ExposedDataexchangePort: serviceBase + 5,
-		ExposedIPFSApiPort:      serviceBase + 6,
-		ExposedIPFSGWPort:       serviceBase + 7,
-		External:                external,
-		OrgName:                 options.OrgNames[index],
-		NodeName:                options.NodeNames[index],
+		ID:                         id,
+		Index:                      &index,
+		ExposedFireflyPort:         options.FireFlyBasePort + index,
+		ExposedFireflyAdminSPIPort: serviceBase + 1, // note shared blockchain node is on zero
+		ExposedConnectorPort:       serviceBase + 2,
+		ExposedUIPort:              serviceBase + 3,
+		ExposedDatabasePort:        serviceBase + 4,
+		ExposedDataexchangePort:    serviceBase + 5,
+		ExposedIPFSApiPort:         serviceBase + 6,
+		ExposedIPFSGWPort:          serviceBase + 7,
+		External:                   external,
+		OrgName:                    options.OrgNames[index],
+		NodeName:                   options.NodeNames[index],
 	}
 	nextPort := serviceBase + 8
 	if options.PrometheusEnabled {
@@ -700,7 +700,7 @@ func (s *StackManager) checkPortsAvailable() error {
 		ports = append(ports, member.ExposedDataexchangePort)
 		ports = append(ports, member.ExposedConnectorPort)
 		if !member.External {
-			ports = append(ports, member.ExposedFireflyAdminPort)
+			ports = append(ports, member.ExposedFireflyAdminSPIPort)
 			ports = append(ports, member.ExposedFireflyPort)
 			ports = append(ports, member.ExposedFireflyMetricsPort)
 		}
@@ -921,7 +921,7 @@ func (s *StackManager) ensureFireflyNodesUp(firstTimeSetup bool) error {
 			configFilename := filepath.Join(s.Stack.RuntimeDir, "config", fmt.Sprintf("firefly_core_%v.yml", member.ID))
 			var port int
 			if firstTimeSetup {
-				port = member.ExposedFireflyAdminPort
+				port = member.ExposedFireflyAdminSPIPort
 			} else {
 				port = member.ExposedFireflyPort
 			}

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -97,22 +97,22 @@ func (s *Stack) IsOldFileStructure() (bool, error) {
 }
 
 type Member struct {
-	ID                        string      `json:"id,omitempty"`
-	Index                     *int        `json:"index,omitempty"`
-	Account                   interface{} `json:"account,omitempty"`
-	ExposedFireflyPort        int         `json:"exposedFireflyPort,omitempty"`
-	ExposedFireflyAdminPort   int         `json:"exposedFireflyAdminPort,omitempty"`
-	ExposedFireflyMetricsPort int         `json:"exposedFireflyMetricsPort,omitempty"`
-	ExposedConnectorPort      int         `json:"exposedConnectorPort,omitempty"`
-	ExposedDatabasePort       int         `json:"exposedPostgresPort,omitempty"`
-	ExposedDataexchangePort   int         `json:"exposedDataexchangePort,omitempty"`
-	ExposedIPFSApiPort        int         `json:"exposedIPFSApiPort,omitempty"`
-	ExposedIPFSGWPort         int         `json:"exposedIPFSGWPort,omitempty"`
-	ExposedUIPort             int         `json:"exposedUiPort,omitempty"`
-	ExposedSandboxPort        int         `json:"exposedSandboxPort,omitempty"`
-	ExposedFFTMPort           int         `json:"exposedFFTMPort,omitempty"`
-	ExposedTokensPorts        []int       `json:"exposedTokensPorts,omitempty"`
-	External                  bool        `json:"external,omitempty"`
-	OrgName                   string      `json:"orgName,omitempty"`
-	NodeName                  string      `json:"nodeName,omitempty"`
+	ID                         string      `json:"id,omitempty"`
+	Index                      *int        `json:"index,omitempty"`
+	Account                    interface{} `json:"account,omitempty"`
+	ExposedFireflyPort         int         `json:"exposedFireflyPort,omitempty"`
+	ExposedFireflyAdminSPIPort int         `json:"exposedFireflyAdminPort,omitempty"` // stack.json still contains the word "Admin" (rather than SPI) for migration
+	ExposedFireflyMetricsPort  int         `json:"exposedFireflyMetricsPort,omitempty"`
+	ExposedConnectorPort       int         `json:"exposedConnectorPort,omitempty"`
+	ExposedDatabasePort        int         `json:"exposedPostgresPort,omitempty"`
+	ExposedDataexchangePort    int         `json:"exposedDataexchangePort,omitempty"`
+	ExposedIPFSApiPort         int         `json:"exposedIPFSApiPort,omitempty"`
+	ExposedIPFSGWPort          int         `json:"exposedIPFSGWPort,omitempty"`
+	ExposedUIPort              int         `json:"exposedUiPort,omitempty"`
+	ExposedSandboxPort         int         `json:"exposedSandboxPort,omitempty"`
+	ExposedFFTMPort            int         `json:"exposedFFTMPort,omitempty"`
+	ExposedTokensPorts         []int       `json:"exposedTokensPorts,omitempty"`
+	External                   bool        `json:"external,omitempty"`
+	OrgName                    string      `json:"orgName,omitempty"`
+	NodeName                   string      `json:"nodeName,omitempty"`
 }


### PR DESCRIPTION
- Updates FFTM images to work with new alpha
- Updates FireFly Signer image to latest release
- Adds an `spi` config section for the new SPI, which supersedes the Admin API
  - Note the old `admin` config section is not removed, as the FireFly CLI needs to generate config that works for the V1.0.x stream still, and without this section the admin API would be turned off in V1.0.x

With this the instructions in https://gist.github.com/peterbroadhurst/63b147c679f76d485523650e76796009 can be executed successfully (instructions updated to use the `alpha` channel, rather than source builds).