### PR TITLE
lowercase `firstevent` json for ffcore parsing

### DIFF
--- a/pkg/types/namespace.go
+++ b/pkg/types/namespace.go
@@ -41,7 +41,7 @@ type MultipartyConfig struct {
 
 type ContractConfig struct {
 	Location   interface{} `yaml:"location"`
-	FirstEvent string      `yaml:"firstEvent"`
+	FirstEvent string      `yaml:"firstevent"`
 }
 
 type MultipartyOrgConfig struct {


### PR DESCRIPTION
until @awrichar's changes in https://github.com/spf13/viper/pull/1387 are released, `firstEvent` must be lowercase for ff core to parse successfully. 