### PR TITLE
Skip creation of IPFS and DX when multiparty is disabled

### DIFF
--- a/internal/docker/docker_checks.go
+++ b/internal/docker/docker_checks.go
@@ -1,3 +1,19 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package docker
 
 import (
@@ -11,20 +27,20 @@ func CheckDockerConfig() error {
 	dockerCmd := exec.Command("docker", "-v")
 	_, err := dockerCmd.Output()
 	if err != nil {
-		return fmt.Errorf("An error occurred while running docker. Is docker installed on your computer?")
+		return fmt.Errorf("an error occurred while running docker. Is docker installed on your computer?")
 	}
 
 	dockerComposeCmd := exec.Command("docker-compose", "-v")
 	_, err = dockerComposeCmd.Output()
 
 	if err != nil {
-		return fmt.Errorf("An error occurred while running docker-compose. Is docker-compose installed on your computer?")
+		return fmt.Errorf("an error occurred while running docker-compose. Is docker-compose installed on your computer?")
 	}
 
 	dockerDeamonCheck := exec.Command("docker", "ps")
 	_, err = dockerDeamonCheck.Output()
 	if err != nil {
-		return fmt.Errorf("An error occurred while running docker. Is docker running on your computer?")
+		return fmt.Errorf("an error occurred while running docker. Is docker running on your computer?")
 	}
 
 	return nil

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2022 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -95,12 +95,13 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 					fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
 					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminSPIPort, member.ExposedFireflyAdminSPIPort),
 				},
-				Volumes: []string{fmt.Sprintf("%s:/etc/firefly/firefly.core.yml:ro", configFile)},
-				DependsOn: map[string]map[string]string{
-					"dataexchange_" + member.ID: {"condition": "service_started"},
-					"ipfs_" + member.ID:         {"condition": "service_healthy"},
-				},
-				Logging: StandardLogOptions,
+				Volumes:   []string{fmt.Sprintf("%s:/etc/firefly/firefly.core.yml:ro", configFile)},
+				DependsOn: map[string]map[string]string{},
+				Logging:   StandardLogOptions,
+			}
+			if s.MultipartyEnabled {
+				compose.Services["firefly_core_"+member.ID].DependsOn["dataexchange_"+member.ID] = map[string]string{"condition": "service_started"}
+				compose.Services["firefly_core_"+member.ID].DependsOn["ipfs_"+member.ID] = map[string]string{"condition": "service_healthy"}
 			}
 		}
 		if s.Database == "postgres" {
@@ -126,37 +127,39 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				service.DependsOn["postgres_"+member.ID] = map[string]string{"condition": "service_healthy"}
 			}
 		}
-		compose.Services["ipfs_"+member.ID] = &Service{
-			Image:         constants.IPFSImageName,
-			ContainerName: fmt.Sprintf("%s_ipfs_%s", s.Name, member.ID),
-			Ports: []string{
-				fmt.Sprintf("%d:5001", member.ExposedIPFSApiPort),
-				fmt.Sprintf("%d:8080", member.ExposedIPFSGWPort),
-			},
-			Environment: map[string]interface{}{
-				"IPFS_SWARM_KEY":    s.SwarmKey,
-				"LIBP2P_FORCE_PNET": "1",
-			},
-			Volumes: []string{
-				fmt.Sprintf("ipfs_staging_%s:/export", member.ID),
-				fmt.Sprintf("ipfs_data_%s:/data/ipfs", member.ID),
-			},
-			Logging: StandardLogOptions,
-			HealthCheck: &HealthCheck{
-				Test:     []string{"CMD-SHELL", `wget --post-data= http://127.0.0.1:5001/api/v0/id -O - -q`},
-				Interval: "5s",
-				Timeout:  "3s",
-				Retries:  12,
-			},
-		}
-		compose.Volumes[fmt.Sprintf("ipfs_staging_%s", member.ID)] = struct{}{}
-		compose.Volumes[fmt.Sprintf("ipfs_data_%s", member.ID)] = struct{}{}
-		compose.Services["dataexchange_"+member.ID] = &Service{
-			Image:         s.VersionManifest.DataExchange.GetDockerImageString(),
-			ContainerName: fmt.Sprintf("%s_dataexchange_%s", s.Name, member.ID),
-			Ports:         []string{fmt.Sprintf("%d:3000", member.ExposedDataexchangePort)},
-			Volumes:       []string{fmt.Sprintf("dataexchange_%s:/data", member.ID)},
-			Logging:       StandardLogOptions,
+		if s.MultipartyEnabled {
+			compose.Services["ipfs_"+member.ID] = &Service{
+				Image:         constants.IPFSImageName,
+				ContainerName: fmt.Sprintf("%s_ipfs_%s", s.Name, member.ID),
+				Ports: []string{
+					fmt.Sprintf("%d:5001", member.ExposedIPFSApiPort),
+					fmt.Sprintf("%d:8080", member.ExposedIPFSGWPort),
+				},
+				Environment: map[string]interface{}{
+					"IPFS_SWARM_KEY":    s.SwarmKey,
+					"LIBP2P_FORCE_PNET": "1",
+				},
+				Volumes: []string{
+					fmt.Sprintf("ipfs_staging_%s:/export", member.ID),
+					fmt.Sprintf("ipfs_data_%s:/data/ipfs", member.ID),
+				},
+				Logging: StandardLogOptions,
+				HealthCheck: &HealthCheck{
+					Test:     []string{"CMD-SHELL", `wget --post-data= http://127.0.0.1:5001/api/v0/id -O - -q`},
+					Interval: "5s",
+					Timeout:  "3s",
+					Retries:  12,
+				},
+			}
+			compose.Volumes[fmt.Sprintf("ipfs_staging_%s", member.ID)] = struct{}{}
+			compose.Volumes[fmt.Sprintf("ipfs_data_%s", member.ID)] = struct{}{}
+			compose.Services["dataexchange_"+member.ID] = &Service{
+				Image:         s.VersionManifest.DataExchange.GetDockerImageString(),
+				ContainerName: fmt.Sprintf("%s_dataexchange_%s", s.Name, member.ID),
+				Ports:         []string{fmt.Sprintf("%d:3000", member.ExposedDataexchangePort)},
+				Volumes:       []string{fmt.Sprintf("dataexchange_%s:/data", member.ID)},
+				Logging:       StandardLogOptions,
+			}
 		}
 		compose.Volumes[fmt.Sprintf("dataexchange_%s", member.ID)] = struct{}{}
 		if s.SandboxEnabled {


### PR DESCRIPTION
This will reduce the number of docker containers needed to run when multiparty mode has been disabled. Previously, IPFS and DX were there just sitting idle.