### PR TITLE
Restore camelCase key names

### DIFF
--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -837,7 +837,6 @@ func (s *StackManager) runFirstTimeSetup(options *types.StartOptions) (messages 
 			Predefined: []*types.Namespace{
 				{
 					Name:        "default",
-					RemoteName:  "default",
 					Description: "Default predefined namespace",
 					Plugins:     []string{"database0", "blockchain0"},
 				},

--- a/pkg/types/namespace.go
+++ b/pkg/types/namespace.go
@@ -18,11 +18,10 @@ package types
 
 type Namespace struct {
 	Name        string            `yaml:"name"`
-	RemoteName  string            `yaml:"remotename,omitempty"`
 	Description string            `yaml:"description,omitempty"`
 	Plugins     []string          `yaml:"plugins"`
 	Multiparty  *MultipartyConfig `yaml:"multiparty,omitempty"`
-	DefaultKey  interface{}       `yaml:"defaultkey"`
+	DefaultKey  interface{}       `yaml:"defaultKey"`
 }
 
 type Plugins struct {
@@ -41,7 +40,7 @@ type MultipartyConfig struct {
 
 type ContractConfig struct {
 	Location   interface{} `yaml:"location"`
-	FirstEvent string      `yaml:"firstevent"`
+	FirstEvent string      `yaml:"firstEvent"`
 }
 
 type MultipartyOrgConfig struct {


### PR DESCRIPTION
Since the Viper patch has been absorbed into main, it's OK to use
camelCase in config files again.

Counterpart to https://github.com/hyperledger/firefly/pull/988