### PR TITLE
fix error reporting

### DIFF
--- a/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
+++ b/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
@@ -62,7 +62,7 @@ func (p *RemoteRPCProvider) WriteConfig(options *types.InitOptions) error {
 		// Generate the connector config for each member
 		connectorConfigPath := filepath.Join(initDir, "config", fmt.Sprintf("%s_%v.yaml", p.connector.Name(), i))
 		if err := p.connector.GenerateConfig(member, "ethsigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
-			return nil
+			return err
 		}
 
 	}


### PR DESCRIPTION
When incorrect file name passed to `ff init --connector-config ` there is no error.  With this PR, the error is reported
```
Error: Failed to load url : 404 : file:///path/to/file.yaml
```
Signed-off-by: John Hosie <john.hosie@kaleido.io>