### PR TITLE
Fix link to contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions to the FireFly Project in many forms, and
 there's always plenty to do!
 
 Please visit the
-[contributors guide](https://hyperledger.github.io/firefly/contributors/contributors.html) in the
+[contributors guide](https://hyperledger.github.io/firefly/contributors/) in the
 docs to learn how to make contributions to this exciting project.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
replacing `https://hyperledger.github.io/firefly/contributors/contributors.html` with `https://hyperledger.github.io/firefly/contributors/`