### PR TITLE
Add brew tap for firefly-cli release through goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ release:
   prerelease: auto
 brews:
   - tap:
-      owner: firefly-cli
+      owner: hyperledger
       name: homebrew-packages
     download_strategy: <> # e.g. GitHubPrivateRepositoryReleaseDownloadStrategy
     folder: Formula
@@ -56,4 +56,4 @@ brews:
       <>
     test: |
       <>
-    skip_upload: <true/false>
+    skip_upload: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,3 +44,16 @@ changelog:
       - '^test:'
 release:
   prerelease: auto
+brews:
+  - tap:
+      owner: firefly-cli
+      name: homebrew-packages
+    download_strategy: <> # e.g. GitHubPrivateRepositoryReleaseDownloadStrategy
+    folder: Formula
+    homepage: "https://github.com/hyperledger/firefly-cli"
+    description: "Create local FireFly stacks for offline development of blockchain apps"
+    install: |
+      <>
+    test: |
+      <>
+    skip_upload: <true/false>


### PR DESCRIPTION
This PR adds `brews` section to `.goreleaser.yml` file.

use on commandline:
```
brew tap hyperledger/packages/firefly-cli
brew install firefly-cli
```

TODO: create repo `hyperledger/homebrew-packages`
- this is where homebrew will store the .rb file under `Formula` folder

ISSUE: [https://github.com/hyperledger/firefly-cli/issues/59](https://github.com/hyperledger/firefly-cli/issues/59)

- Signed-off-by: Garima Negi <garima.negy@gmail.com>