### PR TITLE
Allow contract constructor params

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions to the FireFly Project in many forms, and
 there's always plenty to do!
 
 Please visit the
-[contributors guide](https://hyperledger.github.io/firefly/contributors/contributors.html) in the
+[contributors guide](https://hyperledger.github.io/firefly/contributors/index.html) in the
 docs to learn how to make contributions to this exciting project.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/cmd/deploy_ethereum.go
+++ b/cmd/deploy_ethereum.go
@@ -28,15 +28,16 @@ import (
 
 // deployEthereumCmd represents the "deploy ethereum" command
 var deployEthereumCmd = &cobra.Command{
-	Use:   "ethereum <stack_name> <contract_json_file>",
+	Use:   "ethereum <stack_name> <contract_json_file> [constructor_param1 [constructor_param2 ...]]",
 	Short: "Deploy a compiled solidity contract",
-	Long: `Deploy a solidity contract compiled with solc to the blockchain used by a FireFly stack
+	Long: `Deploy a solidity contract compiled with solc to the blockchain used by a FireFly stack. If the
+contract has a constructor that takes arguments specify them as arguments to the command after the filename.
 
 To compile a .sol file to a .json file run:
 
 solc --combined-json abi,bin contract.sol > contract.json
 `,
-	Args: cobra.ExactArgs(2),
+	Args: cobra.MinimumNArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return docker.CheckDockerConfig()
 	},


### PR DESCRIPTION
I think when the fabric and ethereum commands were split out the argument checking became too strict and prevent the "params" JSON header from being set to anything other than an empty array. For smart contracts with constructors that take parameters this means you can't provide the vars needed at deploy time.