### PR TITLE
When --prometheus-enabled is set, add FFTM metric configuration to prometheus.yml and evmconnect_*.yaml

### DIFF
--- a/internal/blockchain/ethereum/besu/besu_provider.go
+++ b/internal/blockchain/ethereum/besu/besu_provider.go
@@ -70,7 +70,7 @@ func (p *BesuProvider) WriteConfig(options *types.InitOptions) error {
 
 		// Generate the connector config for each member
 		connectorConfigPath := filepath.Join(initDir, "config", fmt.Sprintf("%s_%v.yaml", p.connector.Name(), i))
-		if err := p.connector.GenerateConfig(member, "ethsigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
+		if err := p.connector.GenerateConfig(p.stack, member, "ethsigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
 			return nil
 		}
 

--- a/internal/blockchain/ethereum/connector/connector_interface.go
+++ b/internal/blockchain/ethereum/connector/connector_interface.go
@@ -25,7 +25,7 @@ import (
 type Connector interface {
 	GetServiceDefinitions(s *types.Stack, dependentServices map[string]string) []*docker.ServiceDefinition
 	DeployContract(contract *ethtypes.CompiledContract, contractName string, member *types.Organization, extraArgs []string) (*types.ContractDeploymentResult, error)
-	GenerateConfig(member *types.Organization, blockchainServiceName string) Config
+	GenerateConfig(stack *types.Stack, member *types.Organization, blockchainServiceName string) Config
 	Name() string
 	Port() int
 }

--- a/internal/blockchain/ethereum/connector/ethconnect/config.go
+++ b/internal/blockchain/ethereum/connector/ethconnect/config.go
@@ -78,7 +78,7 @@ func (e *Config) WriteConfig(filename string, extraConnectorConfigPath string) e
 	return nil
 }
 
-func (e *Ethconnect) GenerateConfig(member *types.Organization, blockchainServiceName string) connector.Config {
+func (e *Ethconnect) GenerateConfig(stack *types.Stack, member *types.Organization, blockchainServiceName string) connector.Config {
 	return &Config{
 		Rest: &Rest{
 			RestGateway: &RestGateway{

--- a/internal/blockchain/ethereum/geth/geth_provider.go
+++ b/internal/blockchain/ethereum/geth/geth_provider.go
@@ -68,7 +68,7 @@ func (p *GethProvider) WriteConfig(options *types.InitOptions) error {
 	for i, member := range p.stack.Members {
 		// Generate the connector config for each member
 		connectorConfigPath := filepath.Join(initDir, "config", fmt.Sprintf("%s_%v.yaml", p.connector.Name(), i))
-		if err := p.connector.GenerateConfig(member, "geth").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
+		if err := p.connector.GenerateConfig(p.stack, member, "geth").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
 			return nil
 		}
 	}

--- a/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
+++ b/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
@@ -61,7 +61,7 @@ func (p *RemoteRPCProvider) WriteConfig(options *types.InitOptions) error {
 
 		// Generate the connector config for each member
 		connectorConfigPath := filepath.Join(initDir, "config", fmt.Sprintf("%s_%v.yaml", p.connector.Name(), i))
-		if err := p.connector.GenerateConfig(member, "ethsigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
+		if err := p.connector.GenerateConfig(p.stack, member, "ethsigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
 			return err
 		}
 

--- a/internal/stacks/prometheus_config.go
+++ b/internal/stacks/prometheus_config.go
@@ -43,6 +43,10 @@ func (s *StackManager) GeneratePrometheusConfig() *PrometheusConfig {
 
 	for i, member := range s.Stack.Members {
 		config.ScrapeConfigs[0].StaticConfigs[0].Targets = append(config.ScrapeConfigs[0].StaticConfigs[0].Targets, fmt.Sprintf("firefly_core_%d:%d", i, member.ExposedFireflyMetricsPort))
+
+		if s.blockchainProvider.GetConnectorName() == "evmconnect" {
+			config.ScrapeConfigs[0].StaticConfigs[0].Targets = append(config.ScrapeConfigs[0].StaticConfigs[0].Targets, fmt.Sprintf("evmconnect_%d:%d", i, member.ExposedConnectorMetricsPort))
+		}
 	}
 
 	return config

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -540,6 +540,8 @@ func (s *StackManager) createMember(id string, index int, options *types.InitOpt
 	if options.PrometheusEnabled {
 		member.ExposedFireflyMetricsPort = nextPort
 		nextPort++
+		member.ExposedConnectorMetricsPort = nextPort
+		nextPort++
 	}
 	for range options.TokenProviders {
 		member.ExposedTokensPorts = append(member.ExposedTokensPorts, nextPort)

--- a/pkg/types/organization.go
+++ b/pkg/types/organization.go
@@ -17,22 +17,23 @@
 package types
 
 type Organization struct {
-	ID                         string       `json:"id,omitempty"`
-	Index                      *int         `json:"index,omitempty"`
-	Account                    interface{}  `json:"account,omitempty"`
-	ExposedFireflyPort         int          `json:"exposedFireflyPort,omitempty"`
-	ExposedFireflyAdminSPIPort int          `json:"exposedFireflyAdminPort,omitempty"` // stack.json still contains the word "Admin" (rather than SPI) for migration
-	ExposedFireflyMetricsPort  int          `json:"exposedFireflyMetricsPort,omitempty"`
-	ExposedConnectorPort       int          `json:"exposedConnectorPort,omitempty"`
-	ExposedDatabasePort        int          `json:"exposedPostgresPort,omitempty"`
-	ExposedDataexchangePort    int          `json:"exposedDataexchangePort,omitempty"`
-	ExposedIPFSApiPort         int          `json:"exposedIPFSApiPort,omitempty"`
-	ExposedIPFSGWPort          int          `json:"exposedIPFSGWPort,omitempty"`
-	ExposedUIPort              int          `json:"exposedUiPort,omitempty"`
-	ExposedSandboxPort         int          `json:"exposedSandboxPort,omitempty"`
-	ExposedTokensPorts         []int        `json:"exposedTokensPorts,omitempty"`
-	External                   bool         `json:"external,omitempty"`
-	OrgName                    string       `json:"orgName,omitempty"`
-	NodeName                   string       `json:"nodeName,omitempty"`
-	Namespaces                 []*Namespace `json:"namespaces"`
+	ID                          string       `json:"id,omitempty"`
+	Index                       *int         `json:"index,omitempty"`
+	Account                     interface{}  `json:"account,omitempty"`
+	ExposedFireflyPort          int          `json:"exposedFireflyPort,omitempty"`
+	ExposedFireflyAdminSPIPort  int          `json:"exposedFireflyAdminPort,omitempty"` // stack.json still contains the word "Admin" (rather than SPI) for migration
+	ExposedFireflyMetricsPort   int          `json:"exposedFireflyMetricsPort,omitempty"`
+	ExposedConnectorPort        int          `json:"exposedConnectorPort,omitempty"`
+	ExposedConnectorMetricsPort int          `json:"exposedConnectorMetricsPort,omitempty"`
+	ExposedDatabasePort         int          `json:"exposedPostgresPort,omitempty"`
+	ExposedDataexchangePort     int          `json:"exposedDataexchangePort,omitempty"`
+	ExposedIPFSApiPort          int          `json:"exposedIPFSApiPort,omitempty"`
+	ExposedIPFSGWPort           int          `json:"exposedIPFSGWPort,omitempty"`
+	ExposedUIPort               int          `json:"exposedUiPort,omitempty"`
+	ExposedSandboxPort          int          `json:"exposedSandboxPort,omitempty"`
+	ExposedTokensPorts          []int        `json:"exposedTokensPorts,omitempty"`
+	External                    bool         `json:"external,omitempty"`
+	OrgName                     string       `json:"orgName,omitempty"`
+	NodeName                    string       `json:"nodeName,omitempty"`
+	Namespaces                  []*Namespace `json:"namespaces"`
 }


### PR DESCRIPTION
This PR relates to PR https://github.com/hyperledger/firefly-transaction-manager/pull/41 which adds support for prometheus metrics in FFTM.

Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>