### PR TITLE
Print logs to stdout without needing --verbose to be specified

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -37,6 +37,7 @@ The most recent logs can be viewed, or you can follow the
 output with the -f flag.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
+		ctx = context.WithValue(ctx, docker.CtxIsLogCmd{}, true)
 		ctx = log.WithLogger(ctx, logger)
 		if err := docker.CheckDockerConfig(); err != nil {
 			return err

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -30,6 +30,10 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/log"
 )
 
+type (
+	CtxIsLogCmd struct{}
+)
+
 func CreateVolume(ctx context.Context, volumeName string) error {
 	return RunDockerCommand(ctx, ".", "volume", "create", volumeName)
 }
@@ -91,6 +95,7 @@ func RunDockerCommandBuffered(ctx context.Context, workingDir string, command ..
 
 func runCommand(ctx context.Context, cmd *exec.Cmd) (string, error) {
 	verbose := log.VerbosityFromContext(ctx)
+	isLogCmd, _ := ctx.Value(CtxIsLogCmd{}).(bool)
 	if verbose {
 		fmt.Println(cmd.String())
 	}
@@ -104,7 +109,7 @@ outputCapture:
 	for {
 		select {
 		case s, ok := <-stdoutChan:
-			if verbose {
+			if isLogCmd || verbose {
 				if !ok {
 					break outputCapture
 				}


### PR DESCRIPTION
Closes https://github.com/hyperledger/firefly-cli/issues/214

Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>