### PR TITLE
Add support for external Fabric networks

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -100,11 +100,13 @@ func initCommon(args []string) error {
 		if err := validateCount(memberCountInput); err != nil {
 			return err
 		}
+		memberCount, _ := strconv.Atoi(memberCountInput)
+		initOptions.MemberCount = memberCount
 	} else if initOptions.MemberCount == 0 {
 		memberCountInput, _ = prompt("number of members: ", validateCount)
+		memberCount, _ := strconv.Atoi(memberCountInput)
+		initOptions.MemberCount = memberCount
 	}
-	memberCount, _ := strconv.Atoi(memberCountInput)
-	initOptions.MemberCount = memberCount
 
 	initOptions.OrgNames = make([]string, 0, initOptions.MemberCount)
 	initOptions.NodeNames = make([]string, 0, initOptions.MemberCount)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -114,8 +116,9 @@ func initCommon(args []string) error {
 		}
 	} else {
 		for i := 0; i < initOptions.MemberCount; i++ {
-			initOptions.OrgNames = append(initOptions.OrgNames, fmt.Sprintf("org_%d", i))
-			initOptions.NodeNames = append(initOptions.NodeNames, fmt.Sprintf("node_%d", i))
+			id := randomHexString(3)
+			initOptions.OrgNames = append(initOptions.OrgNames, fmt.Sprintf("org_%s", id))
+			initOptions.NodeNames = append(initOptions.NodeNames, fmt.Sprintf("node_%s", id))
 		}
 	}
 
@@ -212,6 +215,12 @@ func validateReleaseChannel(input string) error {
 func validateIPFSMode(input string) error {
 	_, err := fftypes.FFEnumParseString(context.Background(), types.IPFSMode, input)
 	return err
+}
+
+func randomHexString(length int) string {
+	bytes := make([]byte, length)
+	rand.Read(bytes)
+	return hex.EncodeToString(bytes)
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -102,9 +102,9 @@ func initCommon(args []string) error {
 		}
 	} else if initOptions.MemberCount == 0 {
 		memberCountInput, _ = prompt("number of members: ", validateCount)
-		memberCount, _ := strconv.Atoi(memberCountInput)
-		initOptions.MemberCount = memberCount
 	}
+	memberCount, _ := strconv.Atoi(memberCountInput)
+	initOptions.MemberCount = memberCount
 
 	initOptions.OrgNames = make([]string, 0, initOptions.MemberCount)
 	initOptions.NodeNames = make([]string, 0, initOptions.MemberCount)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,6 +55,7 @@ var initCmd = &cobra.Command{
 			return err
 		}
 		if err := stackManager.InitStack(&initOptions); err != nil {
+			stackManager.RemoveStack()
 			return err
 		}
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", initOptions.StackName, rootCmd.Use, initOptions.StackName)

--- a/cmd/init_ethereum.go
+++ b/cmd/init_ethereum.go
@@ -43,6 +43,7 @@ var initEthereumCmd = &cobra.Command{
 			return err
 		}
 		if err := stackManager.InitStack(&initOptions); err != nil {
+			stackManager.RemoveStack()
 			return err
 		}
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", stackName, rootCmd.Use, stackName)

--- a/cmd/init_ethereum.go
+++ b/cmd/init_ethereum.go
@@ -1,0 +1,63 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/firefly-cli/internal/log"
+	"github.com/hyperledger/firefly-cli/internal/stacks"
+	"github.com/hyperledger/firefly-cli/pkg/types"
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
+)
+
+var initEthereumCmd = &cobra.Command{
+	Use:   "ethereum [stack_name] [member_count]",
+	Short: "Create a new FireFly local dev stack using an Ethereum blockchain",
+	Long:  `Create a new FireFly local dev stack using an Ethereum blockchain`,
+	Args:  cobra.MaximumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := log.WithVerbosity(context.Background(), verbose)
+		ctx = log.WithLogger(ctx, logger)
+		var stackName string
+		stackManager := stacks.NewStackManager(ctx)
+		if err := initCommon(args); err != nil {
+			return err
+		}
+		if err := stackManager.InitStack(&initOptions); err != nil {
+			return err
+		}
+		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", stackName, rootCmd.Use, stackName)
+		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", filepath.Join(stackManager.Stack.StackDir, "docker-compose.yml"))
+		return nil
+	},
+}
+
+func init() {
+	initEthereumCmd.Flags().IntVar(&initOptions.BlockPeriod, "block-period", -1, "Block period in seconds. Default is variable based on selected blockchain provider.")
+	initEthereumCmd.Flags().StringVar(&initOptions.ContractAddress, "contract-address", "", "Do not automatically deploy a contract, instead use a pre-configured address")
+	initEthereumCmd.Flags().StringVar(&initOptions.RemoteNodeURL, "remote-node-url", "", "For cases where the node is pre-existing and running remotely")
+	initEthereumCmd.Flags().Int64Var(&initOptions.ChainID, "chain-id", 2021, "The chain ID - also used as the network ID")
+	initEthereumCmd.Flags().StringVarP(&initOptions.BlockchainConnector, "blockchain-connector", "c", "evmconnect", "Blockchain connector to use. Options are: [evnconnect ethconnect]")
+	initEthereumCmd.Flags().StringVarP(&initOptions.BlockchainNodeProvider, "blockchain-node", "n", "geth", fmt.Sprintf("Blockchain node type to use. Options are: %v", fftypes.FFEnumValues(types.BlockchainNodeProvider)))
+
+	initCmd.AddCommand(initEthereumCmd)
+}

--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -1,0 +1,76 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/firefly-cli/internal/log"
+	"github.com/hyperledger/firefly-cli/internal/stacks"
+	"github.com/hyperledger/firefly-cli/pkg/types"
+)
+
+var initFabricCmd = &cobra.Command{
+	Use:   "fabric [stack_name] [member_count]",
+	Short: "Create a new FireFly local dev stack using a Fabric network",
+	Long:  `Create a new FireFly local dev stack using a Fabric network`,
+	Args:  cobra.MaximumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := log.WithVerbosity(context.Background(), verbose)
+		ctx = log.WithLogger(ctx, logger)
+		stackManager := stacks.NewStackManager(ctx)
+		initOptions.BlockchainProvider = types.BlockchainProviderFabric.String()
+		initOptions.TokenProviders = []string{}
+		if err := validateFabricFlags(); err != nil {
+			return err
+		}
+		if err := initCommon(args); err != nil {
+			return err
+		}
+		if err := stackManager.InitStack(&initOptions); err != nil {
+			return err
+		}
+		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", initOptions.StackName, rootCmd.Use, initOptions.StackName)
+		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", filepath.Join(stackManager.Stack.StackDir, "docker-compose.yml"))
+		return nil
+	},
+}
+
+func validateFabricFlags() error {
+	if len(initOptions.CCPYAMLPaths) != 0 || len(initOptions.MSPPaths) != 0 {
+		if len(initOptions.CCPYAMLPaths) != len(initOptions.MSPPaths) {
+			return fmt.Errorf("you must provide ccp and msp flags for each organization")
+		}
+		if initOptions.ChannelName == "" || initOptions.ChaincodeName == "" {
+			return fmt.Errorf("channel and chaincode flags must be set when using an external fabric network")
+		}
+		initOptions.MemberCount = len(initOptions.CCPYAMLPaths)
+	}
+	return nil
+}
+
+func init() {
+	initFabricCmd.Flags().StringArrayVar(&initOptions.CCPYAMLPaths, "ccp", nil, "Path to the ccp.yaml file for an org in your Fabric network")
+	initFabricCmd.Flags().StringArrayVar(&initOptions.MSPPaths, "msp", nil, "Path to the MSP directory for an org in your Fabric network")
+	initFabricCmd.Flags().StringVar(&initOptions.ChannelName, "channel", "", "The name of the Fabric channel on which the FireFly chaincode has been deployed")
+	initFabricCmd.Flags().StringVar(&initOptions.ChaincodeName, "chaincode", "", "The name given to the FireFly chaincode when it was deployed")
+	initCmd.AddCommand(initFabricCmd)
+}

--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -46,6 +46,7 @@ var initFabricCmd = &cobra.Command{
 			return err
 		}
 		if err := stackManager.InitStack(&initOptions); err != nil {
+			stackManager.RemoveStack()
 			return err
 		}
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", initOptions.StackName, rootCmd.Use, initOptions.StackName)

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/pkg/types"
+	cp "github.com/otiai10/copy"
 )
 
 type Account struct {
@@ -61,20 +62,32 @@ func NewFabricProvider(ctx context.Context, stack *types.Stack) *FabricProvider 
 
 func (p *FabricProvider) WriteConfig(options *types.InitOptions) error {
 	blockchainDirectory := path.Join(p.stack.InitDir, "blockchain")
-	cryptogenYamlPath := path.Join(blockchainDirectory, "cryptogen.yaml")
 
 	os.MkdirAll(blockchainDirectory, 0755)
+	if p.stack.RemoteFabricNetwork {
+		for i, member := range p.stack.Members {
+			if err := cp.Copy(options.CCPYAMLPaths[i], path.Join(blockchainDirectory, fmt.Sprintf("%s_ccp.yaml", member.ID))); err != nil {
+				return err
+			}
+			if err := cp.Copy(options.MSPPaths[i], path.Join(blockchainDirectory, fmt.Sprintf("%s_msp", member.ID))); err != nil {
+				return err
+			}
+		}
+	} else {
+		cryptogenYamlPath := path.Join(blockchainDirectory, "cryptogen.yaml")
 
-	if err := WriteCryptogenConfig(len(p.stack.Members), cryptogenYamlPath); err != nil {
-		return err
+		if err := WriteCryptogenConfig(len(p.stack.Members), cryptogenYamlPath); err != nil {
+			return err
+		}
+		if err := WriteNetworkConfig(path.Join(blockchainDirectory, "ccp.yaml")); err != nil {
+			return err
+		}
+		if err := p.writeConfigtxYaml(); err != nil {
+			return err
+		}
 	}
-	if err := WriteNetworkConfig(path.Join(blockchainDirectory, "ccp.yaml")); err != nil {
-		return err
-	}
+
 	if err := fabconnect.WriteFabconnectConfig(path.Join(blockchainDirectory, "fabconnect.yaml")); err != nil {
-		return err
-	}
-	if err := p.writeConfigtxYaml(); err != nil {
 		return err
 	}
 
@@ -82,43 +95,44 @@ func (p *FabricProvider) WriteConfig(options *types.InitOptions) error {
 }
 
 func (p *FabricProvider) FirstTimeSetup() error {
-	blockchainDirectory := path.Join(p.stack.RuntimeDir, "blockchain")
-	cryptogenYamlPath := path.Join(blockchainDirectory, "cryptogen.yaml")
-	volumeName := fmt.Sprintf("%s_firefly_fabric", p.stack.Name)
+	if !p.stack.RemoteFabricNetwork {
+		volumeName := fmt.Sprintf("%s_firefly_fabric", p.stack.Name)
+		if err := docker.CreateVolume(p.ctx, volumeName); err != nil {
+			return err
+		}
+		blockchainDirectory := path.Join(p.stack.RuntimeDir, "blockchain")
+		cryptogenYamlPath := path.Join(blockchainDirectory, "cryptogen.yaml")
 
-	if err := docker.CreateVolume(p.ctx, volumeName); err != nil {
-		return err
-	}
+		// Run cryptogen to generate MSP
+		if err := docker.RunDockerCommand(p.ctx, blockchainDirectory,
+			"run",
+			"--platform", getDockerPlatform(),
+			"--rm",
+			"-v", fmt.Sprintf("%s:/etc/template.yml", cryptogenYamlPath),
+			"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
+			FabricToolsImageName,
+			"cryptogen", "generate",
+			"--config", "/etc/template.yml",
+			"--output", "/etc/firefly/organizations",
+		); err != nil {
+			return err
+		}
 
-	// Run cryptogen to generate MSP
-	if err := docker.RunDockerCommand(p.ctx, blockchainDirectory,
-		"run",
-		"--platform", getDockerPlatform(),
-		"--rm",
-		"-v", fmt.Sprintf("%s:/etc/template.yml", cryptogenYamlPath),
-		"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
-		FabricToolsImageName,
-		"cryptogen", "generate",
-		"--config", "/etc/template.yml",
-		"--output", "/etc/firefly/organizations",
-	); err != nil {
-		return err
-	}
-
-	// Generate genesis block
-	if err := docker.RunDockerCommand(p.ctx, blockchainDirectory,
-		"run",
-		"--platform", getDockerPlatform(),
-		"--rm",
-		"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
-		"-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
-		FabricToolsImageName,
-		"configtxgen",
-		"-outputBlock", "/etc/firefly/firefly.block",
-		"-profile", "SingleOrgApplicationGenesis",
-		"-channelID", "firefly",
-	); err != nil {
-		return err
+		// Generate genesis block
+		if err := docker.RunDockerCommand(p.ctx, blockchainDirectory,
+			"run",
+			"--platform", getDockerPlatform(),
+			"--rm",
+			"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
+			"-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
+			FabricToolsImageName,
+			"configtxgen",
+			"-outputBlock", "/etc/firefly/firefly.block",
+			"-profile", "SingleOrgApplicationGenesis",
+			"-channelID", "firefly",
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -126,11 +140,25 @@ func (p *FabricProvider) FirstTimeSetup() error {
 
 func (p *FabricProvider) DeployFireFlyContract() (*types.ContractDeploymentResult, error) {
 	// No config patch YAML required for Fabric, as the chaincode name is pre-determined
+	if p.stack.RemoteFabricNetwork {
+		return &types.ContractDeploymentResult{
+			DeployedContract: &types.DeployedContract{
+				Name: p.stack.ChaincodeName,
+				Location: map[string]string{
+					"channel":   p.stack.ChannelName,
+					"chaincode": p.stack.ChaincodeName,
+				},
+			},
+		}, nil
+	}
 	result, err := p.deploySmartContracts()
 	return result, err
 }
 
 func (p *FabricProvider) deploySmartContracts() (*types.ContractDeploymentResult, error) {
+	if p.stack.RemoteFabricNetwork {
+		return nil, fmt.Errorf("deploying chaincode is not supported with a remote Fabric network")
+	}
 	packageFilename := path.Join(p.stack.RuntimeDir, "contracts", "firefly_fabric.tar.gz")
 
 	if err := p.extractChaincode(); err != nil {
@@ -175,12 +203,14 @@ func (p *FabricProvider) PreStart() error {
 
 func (p *FabricProvider) PostStart(firstTimeSetup bool) error {
 	if firstTimeSetup {
-		if err := p.createChannel(); err != nil {
-			return err
-		}
+		if !p.stack.RemoteFabricNetwork {
+			if err := p.createChannel(); err != nil {
+				return err
+			}
 
-		if err := p.joinChannel(); err != nil {
-			return err
+			if err := p.joinChannel(); err != nil {
+				return err
+			}
 		}
 
 		// Register pre-created identities
@@ -196,6 +226,9 @@ func (p *FabricProvider) PostStart(firstTimeSetup bool) error {
 }
 
 func (p *FabricProvider) GetDockerServiceDefinitions() []*docker.ServiceDefinition {
+	if p.stack.RemoteFabricNetwork {
+		return p.getFabconnectServiceDefinitions(p.stack.Members)
+	}
 	serviceDefinitions := GenerateDockerServiceDefinitions(p.stack)
 	serviceDefinitions = append(serviceDefinitions, p.getFabconnectServiceDefinitions(p.stack.Members)...)
 	return serviceDefinitions
@@ -208,14 +241,13 @@ func (p *FabricProvider) GetBlockchainPluginConfig(stack *types.Stack, m *types.
 	} else {
 		connectorURL = p.GetConnectorURL(m)
 	}
-
 	blockchainConfig = &types.BlockchainConfig{
 		Type: "fabric",
 		Fabric: &types.FabricConfig{
 			Fabconnect: &types.FabconnectConfig{
 				URL:       connectorURL,
-				Chaincode: "firefly",
-				Channel:   "firefly",
+				Chaincode: p.stack.ChaincodeName,
+				Channel:   p.stack.ChannelName,
 				Signer:    m.OrgName,
 				Topic:     m.ID,
 			},
@@ -246,18 +278,11 @@ func (p *FabricProvider) getFabconnectServiceDefinitions(members []*types.Organi
 				Image:         p.stack.VersionManifest.Fabconnect.GetDockerImageString(),
 				ContainerName: fmt.Sprintf("%s_fabconnect_%s", p.stack.Name, member.ID),
 				Command:       "-f /fabconnect/fabconnect.yaml",
-				DependsOn: map[string]map[string]string{
-					"fabric_ca":      {"condition": "service_started"},
-					"fabric_peer":    {"condition": "service_started"},
-					"fabric_orderer": {"condition": "service_started"},
-				},
-				Ports: []string{fmt.Sprintf("%d:3000", member.ExposedConnectorPort)},
+				Ports:         []string{fmt.Sprintf("%d:3000", member.ExposedConnectorPort)},
 				Volumes: []string{
 					fmt.Sprintf("fabconnect_receipts_%s:/fabconnect/receipts", member.ID),
 					fmt.Sprintf("fabconnect_events_%s:/fabconnect/events", member.ID),
 					fmt.Sprintf("%s:/fabconnect/fabconnect.yaml", path.Join(blockchainDirectory, "fabconnect.yaml")),
-					fmt.Sprintf("%s:/fabconnect/ccp.yaml", path.Join(blockchainDirectory, "ccp.yaml")),
-					"firefly_fabric:/etc/firefly",
 				},
 				HealthCheck: &docker.HealthCheck{
 					Test: []string{"CMD", "wget", "-O", "-", "http://localhost:3000/status"},
@@ -267,16 +292,37 @@ func (p *FabricProvider) getFabconnectServiceDefinitions(members []*types.Organi
 			VolumeNames: []string{
 				"fabconnect_receipts_" + member.ID,
 				"fabconnect_events_" + member.ID,
-				"firefly_fabric",
 			},
 		}
+
+		if p.stack.RemoteFabricNetwork {
+			serviceDefinitions[i].Service.Volumes = append(serviceDefinitions[i].Service.Volumes,
+				fmt.Sprintf("%s:/etc/firefly/organizations", path.Join(blockchainDirectory, fmt.Sprintf("%s_msp", member.ID))),
+				fmt.Sprintf("%s:/fabconnect/ccp.yaml", path.Join(blockchainDirectory, fmt.Sprintf("%s_ccp.yaml", member.ID))),
+			)
+		} else {
+			serviceDefinitions[i].Service.DependsOn = map[string]map[string]string{
+				"fabric_ca":      {"condition": "service_started"},
+				"fabric_peer":    {"condition": "service_started"},
+				"fabric_orderer": {"condition": "service_started"},
+			}
+			serviceDefinitions[i].Service.Volumes = append(serviceDefinitions[i].Service.Volumes,
+				"firefly_fabric:/etc/firefly",
+				fmt.Sprintf("%s:/fabconnect/ccp.yaml", path.Join(blockchainDirectory, "ccp.yaml")),
+			)
+			serviceDefinitions[i].VolumeNames = append(serviceDefinitions[i].VolumeNames, "firefly_fabric")
+		}
 	}
+
 	return serviceDefinitions
 }
 
 func (p *FabricProvider) writeConfigtxYaml() error {
-	filePath := path.Join(p.stack.InitDir, "blockchain", "configtx.yaml")
-	return ioutil.WriteFile(filePath, []byte(configtxYaml), 0755)
+	if !p.stack.RemoteFabricNetwork {
+		filePath := path.Join(p.stack.InitDir, "blockchain", "configtx.yaml")
+		return ioutil.WriteFile(filePath, []byte(configtxYaml), 0755)
+	}
+	return nil
 }
 
 func (p *FabricProvider) createChannel() error {

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -563,7 +563,7 @@ func (p *FabricProvider) DeployContract(filename, contractName, instanceName str
 	}
 	result := &types.ContractDeploymentResult{
 		DeployedContract: &types.DeployedContract{
-			Name: "FireFly",
+			Name: contractName,
 			Location: map[string]string{
 				"channel":   channel,
 				"chaincode": chaincode,

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -109,7 +109,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		RemoteNodeURL:     options.RemoteNodeURL,
 		RequestTimeout:    options.RequestTimeout,
 		IPFSMode:          fftypes.FFEnum(options.IPFSMode),
-		ChannelName:       options.ChaincodeName,
+		ChannelName:       options.ChannelName,
 		ChaincodeName:     options.ChaincodeName,
 	}
 

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -30,6 +30,8 @@ type StartOptions struct {
 }
 
 type InitOptions struct {
+	StackName                string
+	MemberCount              int
 	FireFlyBasePort          int
 	ServicesBasePort         int
 	DatabaseProvider         string
@@ -56,6 +58,10 @@ type InitOptions struct {
 	ReleaseChannel           string
 	MultipartyEnabled        bool
 	IPFSMode                 string
+	CCPYAMLPaths             []string
+	MSPPaths                 []string
+	ChannelName              string
+	ChaincodeName            string
 }
 
 const IPFSMode = "ipfs_mode"

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -45,6 +45,9 @@ type Stack struct {
 	DisableTokenFactories  bool             `json:"disableTokenFactories,omitempty"`
 	RequestTimeout         int              `json:"requestTimeout,omitempty"`
 	IPFSMode               fftypes.FFEnum   `json:"ipfsMode"`
+	RemoteFabricNetwork    bool             `json:"remoteFabricNetwork,omitempty"`
+	ChannelName            string           `json:"channelName,omitempty"`
+	ChaincodeName          string           `json:"chaincodeName,omitempty"`
 	InitDir                string           `json:"-"`
 	RuntimeDir             string           `json:"-"`
 	StackDir               string           `json:"-"`


### PR DESCRIPTION
We've had support for external Ethereum RPC nodes for a while now, but we've never had full support for external (not generated by the FireFly CLI) Fabric networks. There's still a fair amount of manual config editing necessary to create a Fabric Common Connection Profile, but I am not aware of any tooling that can autogenerate that at the moment.

There is a corresponding tutorial for using this new capability here:
https://github.com/kaleido-io/firefly/blob/fabric-test-network-tutorial/docs/tutorials/chains/fabric_test_network.md

This PR also splits out the `init` command into two subcommands so we can keep Ethereum and Fabric specific flags separate. The new commands are:

- `ff init ethereum ...`
- `ff init fabric ...`

The existing `ff init` command continues to maintain backwards compatibility for now, but new flags going forward will be added to the newer, more specific subcommands.