### PR TITLE
first draft for supporting docker-compose v2

### DIFF
--- a/cmd/accounts_create.go
+++ b/cmd/accounts_create.go
@@ -33,13 +33,17 @@ var accountsCreateCmd = &cobra.Command{
 	Long:  `Create a new account in the FireFly stack`,
 	Args:  cobra.MinimumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return docker.CheckDockerConfig()
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
+
+		version, err := docker.CheckDockerConfig()
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+		cmd.SetContext(ctx)
+		return err
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
-		stackManager := stacks.NewStackManager(ctx)
+		stackManager := stacks.NewStackManager(cmd.Context())
 		if err := stackManager.LoadStack(stackName); err != nil {
 			return err
 		}

--- a/cmd/accounts_list.go
+++ b/cmd/accounts_list.go
@@ -35,13 +35,17 @@ var accountsListCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Aliases: []string{"ls"},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return docker.CheckDockerConfig()
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
+
+		version, err := docker.CheckDockerConfig()
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+		cmd.SetContext(ctx)
+		return err
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
-		stackManager := stacks.NewStackManager(ctx)
+		stackManager := stacks.NewStackManager(cmd.Context())
 		if err := stackManager.LoadStack(stackName); err != nil {
 			return err
 		}

--- a/cmd/deploy_ethereum.go
+++ b/cmd/deploy_ethereum.go
@@ -39,14 +39,18 @@ solc --combined-json abi,bin contract.sol > contract.json
 `,
 	Args: cobra.MinimumNArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return docker.CheckDockerConfig()
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
+
+		version, err := docker.CheckDockerConfig()
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+		cmd.SetContext(ctx)
+		return err
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 		filename := args[1]
-		stackManager := stacks.NewStackManager(ctx)
+		stackManager := stacks.NewStackManager(cmd.Context())
 		if err := stackManager.LoadStack(stackName); err != nil {
 			return err
 		}

--- a/cmd/deploy_fabric.go
+++ b/cmd/deploy_fabric.go
@@ -33,14 +33,18 @@ var deployFabricCmd = &cobra.Command{
 	Long:  `Deploy a packaged chaincode to the Fabric network used by a FireFly stack`,
 	Args:  cobra.ExactArgs(5),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return docker.CheckDockerConfig()
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
+
+		version, err := docker.CheckDockerConfig()
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+		cmd.SetContext(ctx)
+		return err
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
 		stackName := args[0]
 		filename := args[1]
-		stackManager := stacks.NewStackManager(ctx)
+		stackManager := stacks.NewStackManager(cmd.Context())
 		if err := stackManager.LoadStack(stackName); err != nil {
 			return err
 		}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -34,9 +34,13 @@ var infoCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
-		if err := docker.CheckDockerConfig(); err != nil {
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {
 			return fmt.Errorf("no stack specified")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -37,11 +37,14 @@ The most recent logs can be viewed, or you can follow the
 output with the -f flag.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
-		ctx = context.WithValue(ctx, docker.CtxIsLogCmd{}, true)
+		ctx = context.WithValue(ctx, docker.CtxIsLogCmdKey{}, true)
 		ctx = log.WithLogger(ctx, logger)
-		if err := docker.CheckDockerConfig(); err != nil {
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
 
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -40,9 +40,13 @@ and configuration.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
-		if err := docker.CheckDockerConfig(); err != nil {
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {
 			return fmt.Errorf("no stack specified")

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -39,9 +39,12 @@ Note: this will also stop the stack if it is running.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
-		if err := docker.CheckDockerConfig(); err != nil {
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
 
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -47,9 +47,11 @@ This command will start a stack and run it in the background.
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
 
-		if err := docker.CheckDockerConfig(); err != nil {
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
 
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -34,9 +34,13 @@ var stopCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
-		if err := docker.CheckDockerConfig(); err != nil {
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
 			return err
 		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
+
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {
 			return fmt.Errorf("no stack specified")

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/miracl/conflate v1.2.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/otiai10/copy v1.7.0
-	github.com/spf13/cobra v1.4.0
+	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.1-0.20220712161005-5247643f0235
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,7 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -828,6 +829,8 @@ github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.3.0/go.mod h1:BrRVncBjOJa/eUcVVm9CE+oC6as8k+VYr4NY7WCi9V4=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=

--- a/internal/docker/docker_checks.go
+++ b/internal/docker/docker_checks.go
@@ -21,27 +21,33 @@ import (
 	"os/exec"
 )
 
-// CheckDockerConfig is a function to check docker and docker-compose configuration on the host
-func CheckDockerConfig() error {
+func CheckDockerConfig() (DockerComposeVersion, error) {
 
 	dockerCmd := exec.Command("docker", "-v")
 	_, err := dockerCmd.Output()
 	if err != nil {
-		return fmt.Errorf("an error occurred while running docker. Is docker installed on your computer?")
-	}
-
-	dockerComposeCmd := exec.Command("docker-compose", "-v")
-	_, err = dockerComposeCmd.Output()
-
-	if err != nil {
-		return fmt.Errorf("an error occurred while running docker-compose. Is docker-compose installed on your computer?")
+		return None, fmt.Errorf("an error occurred while running docker. Is docker installed on your computer?")
 	}
 
 	dockerDeamonCheck := exec.Command("docker", "ps")
 	_, err = dockerDeamonCheck.Output()
 	if err != nil {
-		return fmt.Errorf("an error occurred while running docker. Is docker running on your computer?")
+		return None, fmt.Errorf("an error occurred while running docker. Is docker running on your computer?")
 	}
 
-	return nil
+	// ckeck for docker-compose (v1) version
+	dockerComposeCmd := exec.Command("docker-compose", "-v")
+	_, err = dockerComposeCmd.Output()
+	if err == nil {
+		return ComposeV1, nil
+	}
+
+	// ckeck for docker-compose (V2) version
+	dockerComposeCmd = exec.Command("docker compose", "version")
+	_, err = dockerComposeCmd.Output()
+	if err == nil {
+		return ComposeV2, nil
+	}
+
+	return None, fmt.Errorf("an error occurred while running docker-compose. Is docker-compose installed on your computer?")
 }


### PR DESCRIPTION
# Pull Request

## Disclaimer

I'm not a golang developer, so any code presented here is a collection of educated guesses as how to solve the problem.
With that out of the way, let's present the pull request.

## Problem
This pull request adresses [Issue231: firefly fails check for docker compose v2](https://github.com/hyperledger/firefly-cli/issues/231). The problem arises due to docker changing the syntax for docker-compose from `docker-compose` in version 1 to `docker compose` in version 2. There is always the workaround to require the standalone docker-compose in version 1.

## Fix

The fix is split into two parts, adressing the checking of the version and integrating the information into the stack manager that executes the docker commands via `RunDockerComposeCommand`. The information about which version syntax to use for the commands is carried via context.

### CheckDockerConfig
the function that checks for the prerequisites when executing docker-compose commands, `CheckDockerConfig` returns a tuple `(DockerComposeVersion, error)` with `DockerComposeVersion` as enum to differentiate between `None`, `ComposeV1` and `ComposeV2`. This value is stored in a context that is later transferred into the stack manager.
Unfortunately, cobra with version 1.4.0 does not provide the capability to allow context to be attached to a command.
Only from version 1.5.0, this feature has been merged, for reference: [support for SetContext](https://github.com/spf13/cobra/pull/1551).
The solution using cobra 1.5.0 concerns all commands which use both `PreRunE` and `RunE` while also requiring the docker compose version to be transferred as context between these two executions:

```go 
        PreRunE: func(cmd *cobra.Command, args []string) error {
		ctx := ...
		version, err := docker.CheckDockerConfig()
		ctx = context.WithValue(ctx, docker.ComposeVersion{}, version)
		cmd.SetContext(ctx)
		return err
	},
	RunE: func(cmd *cobra.Command, args []string) error {
                ...
		stackManager := stacks.NewStackManager(cmd.Context())
               ...
	},
```

The functions currently affected are defined in:
- `accounts_create.go`
- `accounts_list.go`
- `deploy_ethereum.go`
- `deploy_fabric`

No version update is required when simply combining both executions, similar to functions from:
- `info.go`
- `logs.go`
- `reset.go`
- `start.go`

```go 
        RunE: func(cmd *cobra.Command, args []string) error {
		ctx := ...
		version, err := docker.CheckDockerConfig()
		ctx = context.WithValue(ctx, docker.ComposeVersion{}, version)
                if err != nil {
                     return err
                }
		stackManager := stacks.NewStackManager(cmd.Context())
               ...
	},
```

### RunDockerComposeCommand

The second part of the changes affects the way the stack manager runs docker-compose functions. By retrieving the docker-compose version, either `docker-compose` or `docker compose` can be executed

## Possible Tweaks

- Instead of storing a version in the context, the command itself can be stored; when docker-compose in version 2 is detected, instead storing V1, the string `docker compose` is attached to the context with `ComposeCmd` as key. Consequently, the `RunDockerComposeCommand` function simply executes `exec.Command(ctx.Value(ComposeCmd{}), command...)`.

## Open Question

- Is the separation between `PreRunE` and `RunE` necessary, because currently only docker checks are executed in `PreRun`. Small commands do not even specify `PreRunE` at all.
