### PR TITLE
Fix upgrade command

### DIFF
--- a/cmd/init_ethereum.go
+++ b/cmd/init_ethereum.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -37,7 +37,6 @@ var initEthereumCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
-		var stackName string
 		stackManager := stacks.NewStackManager(ctx)
 		if err := initCommon(args); err != nil {
 			return err
@@ -46,7 +45,7 @@ var initEthereumCmd = &cobra.Command{
 			stackManager.RemoveStack()
 			return err
 		}
-		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", stackName, rootCmd.Use, stackName)
+		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", initOptions.StackName, rootCmd.Use, initOptions.StackName)
 		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", filepath.Join(stackManager.Stack.StackDir, "docker-compose.yml"))
 		return nil
 	},

--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/hyperledger/firefly-cli/internal/docker"
 	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/internal/stacks"
 	"github.com/hyperledger/firefly-cli/pkg/types"
@@ -41,11 +42,16 @@ Pull the images for a stack .
 		var spin *spinner.Spinner
 		if fancyFeatures && !verbose {
 			spin = spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-			spin.FinalMSG = "done"
 			logger = log.NewSpinnerLogger(spin)
 		}
 		ctx := log.WithVerbosity(context.Background(), verbose)
 		ctx = log.WithLogger(ctx, logger)
+
+		version, err := docker.CheckDockerConfig()
+		if err != nil {
+			return err
+		}
+		ctx = context.WithValue(ctx, docker.CtxComposeVersionKey{}, version)
 
 		stackManager := stacks.NewStackManager(ctx)
 		if len(args) == 0 {

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -162,7 +162,7 @@ func getPostgresURL(member *types.Organization) string {
 
 func getSQLitePath(member *types.Organization, runtimeDir string) string {
 	if !member.External {
-		return "/etc/firefly/db?_busy_timeout=5000"
+		return "/etc/firefly/db/sqlite.db?_busy_timeout=5000"
 	} else {
 		return path.Join(runtimeDir, member.ID+".db")
 	}

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -95,10 +95,14 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 					fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
 					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminSPIPort, member.ExposedFireflyAdminSPIPort),
 				},
-				Volumes:   []string{fmt.Sprintf("%s:/etc/firefly/firefly.core.yml:ro", configFile)},
+				Volumes: []string{
+					fmt.Sprintf("%s:/etc/firefly/firefly.core.yml:ro", configFile),
+					fmt.Sprintf("firefly_core_db_%s:/etc/firefly/db", member.ID),
+				},
 				DependsOn: map[string]map[string]string{},
 				Logging:   StandardLogOptions,
 			}
+			compose.Volumes[fmt.Sprintf("firefly_core_db_%s", member.ID)] = struct{}{}
 			compose.Services["firefly_core_"+member.ID].DependsOn["dataexchange_"+member.ID] = map[string]string{"condition": "service_started"}
 			compose.Services["firefly_core_"+member.ID].DependsOn["ipfs_"+member.ID] = map[string]string{"condition": "service_healthy"}
 		}

--- a/internal/log/spin.go
+++ b/internal/log/spin.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
This is a significant change to the way the upgrade command works. Unfortunately I don't think it has really worked for quite some time, due to the way we pin images to specific shas. This change will rewrite the stack.json file and the docker-compose.yml file with the correct image name/tag/sha for the desired version. In theory this also allows for downgrades as well, though that's untested. I successfully tested upgrading from v1.1.3 -> v1.2.0-rc.3. I also tested the same migration with Besu and that worked as well.

Due to the filesystem location of the sqlite DB in previous versions of the FireFly CLI unfortunately the DB is lost in the upgrade. This PR fixes that and stacks created with this version should be upgradable to future FireFly versions. But unfortunately it means that stacks created with previous versions will not have a clean upgrade path.

Resolves https://github.com/hyperledger/firefly-cli/issues/239