### PR TITLE
Add Fabric option for a global (channel-wide) batch pin listener

### DIFF
--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -73,6 +73,6 @@ func init() {
 	initFabricCmd.Flags().StringArrayVar(&initOptions.MSPPaths, "msp", nil, "Path to the MSP directory for an org in your Fabric network")
 	initFabricCmd.Flags().StringVar(&initOptions.ChannelName, "channel", "", "The name of the Fabric channel on which the FireFly chaincode has been deployed")
 	initFabricCmd.Flags().StringVar(&initOptions.ChaincodeName, "chaincode", "", "The name given to the FireFly chaincode when it was deployed")
-	initFabricCmd.Flags().BoolVar(&initOptions.GlobalListener, "global-listener", false, "Configure the blockchain listener to listen for BatchPin events from any chaincode on the channel")
+	initFabricCmd.Flags().BoolVar(&initOptions.CustomPinSupport, "custom-pin-support", false, "Configure the blockchain listener to listen for BatchPin events from any chaincode on the channel")
 	initCmd.AddCommand(initFabricCmd)
 }

--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -73,5 +73,6 @@ func init() {
 	initFabricCmd.Flags().StringArrayVar(&initOptions.MSPPaths, "msp", nil, "Path to the MSP directory for an org in your Fabric network")
 	initFabricCmd.Flags().StringVar(&initOptions.ChannelName, "channel", "", "The name of the Fabric channel on which the FireFly chaincode has been deployed")
 	initFabricCmd.Flags().StringVar(&initOptions.ChaincodeName, "chaincode", "", "The name given to the FireFly chaincode when it was deployed")
+	initFabricCmd.Flags().BoolVar(&initOptions.GlobalListener, "global-listener", false, "Configure the blockchain listener to listen for BatchPin events from any chaincode on the channel")
 	initCmd.AddCommand(initFabricCmd)
 }

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -111,7 +111,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		IPFSMode:          fftypes.FFEnum(options.IPFSMode),
 		ChannelName:       options.ChannelName,
 		ChaincodeName:     options.ChaincodeName,
-		GlobalListener:    options.GlobalListener,
+		CustomPinSupport:  options.CustomPinSupport,
 	}
 
 	tokenProviders, err := types.FFEnumArray(s.ctx, options.TokenProviders)
@@ -913,8 +913,8 @@ func (s *StackManager) runFirstTimeSetup(options *types.StartOptions) (messages 
 				contractLocation = contractDeploymentResult.DeployedContract.Location
 			}
 			options := make(map[string]interface{})
-			if s.Stack.GlobalListener {
-				options["globalListener"] = true
+			if s.Stack.CustomPinSupport {
+				options["customPinSupport"] = true
 			}
 
 			newConfig.Namespaces.Predefined[0].Multiparty = &types.MultipartyConfig{

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -111,6 +111,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		IPFSMode:          fftypes.FFEnum(options.IPFSMode),
 		ChannelName:       options.ChannelName,
 		ChaincodeName:     options.ChaincodeName,
+		GlobalListener:    options.GlobalListener,
 	}
 
 	tokenProviders, err := types.FFEnumArray(s.ctx, options.TokenProviders)
@@ -911,6 +912,11 @@ func (s *StackManager) runFirstTimeSetup(options *types.StartOptions) (messages 
 			} else {
 				contractLocation = contractDeploymentResult.DeployedContract.Location
 			}
+			options := make(map[string]interface{})
+			if s.Stack.GlobalListener {
+				options["globalListener"] = true
+			}
+
 			newConfig.Namespaces.Predefined[0].Multiparty = &types.MultipartyConfig{
 				Enabled: true,
 				Org:     orgConfig,
@@ -920,6 +926,7 @@ func (s *StackManager) runFirstTimeSetup(options *types.StartOptions) (messages 
 				Contract: []*types.ContractConfig{
 					{
 						Location: contractLocation,
+						Options:  options,
 					},
 				},
 			}

--- a/pkg/types/namespace.go
+++ b/pkg/types/namespace.go
@@ -42,6 +42,7 @@ type MultipartyConfig struct {
 type ContractConfig struct {
 	Location   interface{} `yaml:"location"`
 	FirstEvent string      `yaml:"firstEvent"`
+	Options    interface{} `yaml:"options"`
 }
 
 type MultipartyOrgConfig struct {

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -62,7 +62,7 @@ type InitOptions struct {
 	MSPPaths                 []string
 	ChannelName              string
 	ChaincodeName            string
-	GlobalListener           bool
+	CustomPinSupport         bool
 }
 
 const IPFSMode = "ipfs_mode"

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -62,6 +62,7 @@ type InitOptions struct {
 	MSPPaths                 []string
 	ChannelName              string
 	ChaincodeName            string
+	GlobalListener           bool
 }
 
 const IPFSMode = "ipfs_mode"

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -48,7 +48,7 @@ type Stack struct {
 	RemoteFabricNetwork    bool             `json:"remoteFabricNetwork,omitempty"`
 	ChannelName            string           `json:"channelName,omitempty"`
 	ChaincodeName          string           `json:"chaincodeName,omitempty"`
-	GlobalListener         bool             `json:"globalListener,omitempty"`
+	CustomPinSupport       bool             `json:"customPinSupport,omitempty"`
 	InitDir                string           `json:"-"`
 	RuntimeDir             string           `json:"-"`
 	StackDir               string           `json:"-"`

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -48,6 +48,7 @@ type Stack struct {
 	RemoteFabricNetwork    bool             `json:"remoteFabricNetwork,omitempty"`
 	ChannelName            string           `json:"channelName,omitempty"`
 	ChaincodeName          string           `json:"chaincodeName,omitempty"`
+	GlobalListener         bool             `json:"globalListener,omitempty"`
 	InitDir                string           `json:"-"`
 	RuntimeDir             string           `json:"-"`
 	StackDir               string           `json:"-"`


### PR DESCRIPTION
Part of [FIR-17](https://github.com/hyperledger/firefly-fir/pull/17)
Required by https://github.com/hyperledger/firefly/pull/1213