### PR TITLE
Do not set firstEvent to empty string

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -96,7 +96,7 @@ func RunDockerComposeCommand(ctx context.Context, workingDir string, command ...
 		_, err := runCommand(ctx, dockerCmd)
 		return err
 	case ComposeV2:
-		dockerCmd := exec.Command("docker compose", command...)
+		dockerCmd := exec.Command("docker", append([]string{"compose"}, command...)...)
 		dockerCmd.Dir = workingDir
 		_, err := runCommand(ctx, dockerCmd)
 		return err

--- a/internal/docker/docker_checks.go
+++ b/internal/docker/docker_checks.go
@@ -35,15 +35,15 @@ func CheckDockerConfig() (DockerComposeVersion, error) {
 		return None, fmt.Errorf("an error occurred while running docker. Is docker running on your computer?")
 	}
 
-	// ckeck for docker-compose (v1) version
+	// check for docker-compose (v1) version
 	dockerComposeCmd := exec.Command("docker-compose", "-v")
 	_, err = dockerComposeCmd.Output()
 	if err == nil {
 		return ComposeV1, nil
 	}
 
-	// ckeck for docker-compose (V2) version
-	dockerComposeCmd = exec.Command("docker compose", "version")
+	// check for docker-compose (V2) version
+	dockerComposeCmd = exec.Command("docker", "compose", "version")
 	_, err = dockerComposeCmd.Output()
 	if err == nil {
 		return ComposeV2, nil

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -919,7 +919,8 @@ func (s *StackManager) runFirstTimeSetup(options *types.StartOptions) (messages 
 				},
 				Contract: []*types.ContractConfig{
 					{
-						Location: contractLocation,
+						Location:   contractLocation,
+						FirstEvent: "0",
 					},
 				},
 			}

--- a/pkg/types/namespace.go
+++ b/pkg/types/namespace.go
@@ -41,7 +41,7 @@ type MultipartyConfig struct {
 
 type ContractConfig struct {
 	Location   interface{} `yaml:"location"`
-	FirstEvent string      `yaml:"firstEvent"`
+	FirstEvent string      `yaml:"firstEvent,omitempty"`
 }
 
 type MultipartyOrgConfig struct {


### PR DESCRIPTION
The yaml serializer was missing the `omitempty` tag so even though the Go code wasn't setting a value, the `firstEvent` field was getting written to the config as an empty string `""`. Setting it to an empty string causes FireFly to _not_ apply its default setting, which can result in the blockchain connector subscribing from the newest event, rather than the oldest.