### PR TITLE
Allow longer before giving up on dev starting a firefly core

### DIFF
--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -996,7 +996,7 @@ func (s *StackManager) ensureFireflyNodesUp(firstTimeSetup bool) error {
 }
 
 func (s *StackManager) waitForFireflyStart(port int) error {
-	retries := 120
+	retries := 600
 	retryPeriod := 1000 // ms
 	retriesRemaining := retries
 	for retriesRemaining > 0 {


### PR DESCRIPTION
It currently takes me about 5 attempts to start up a dev environment, because the CLI expects me to task-switch back to my commandline within a 2min window (having task switched out to doing something else, when I kicked off `ff start`).

So I'm raising this as a proposal to give me 10mins instead. Hope that's ok