### PR TITLE
Add an option '--remote-node-deploy' to treat remote nodes like local nodes

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -263,5 +263,6 @@ func init() {
 	initCmd.PersistentFlags().StringVar(&initOptions.IPFSMode, "ipfs-mode", "private", fmt.Sprintf("Set the mode in which IFPS operates. Options are: %v", fftypes.FFEnumValues(types.IPFSMode)))
 	initCmd.PersistentFlags().StringArrayVar(&initOptions.OrgNames, "org-name", []string{}, "Organization name")
 	initCmd.PersistentFlags().StringArrayVar(&initOptions.NodeNames, "node-name", []string{}, "Node name")
+	initCmd.PersistentFlags().BoolVar(&initOptions.RemoteNodeDeploy, "remote-node-deploy", false, "Enable or disable deployment of FireFly contracts on remote nodes")
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
+++ b/internal/blockchain/ethereum/remoterpc/remoterpc_provider.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -94,6 +94,13 @@ func (p *RemoteRPCProvider) PostStart(fistTimeSetup bool) error {
 }
 
 func (p *RemoteRPCProvider) DeployFireFlyContract() (*types.ContractDeploymentResult, error) {
+	if p.stack.RemoteNodeDeploy {
+		contract, err := ethereum.ReadFireFlyContract(p.ctx, p.stack)
+		if err != nil {
+			return nil, err
+		}
+		return p.connector.DeployContract(contract, "FireFly", p.stack.Members[0], nil)
+	}
 	return nil, fmt.Errorf("you must pre-deploy your FireFly contract when using a remote RPC endpoint")
 }
 

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -112,6 +112,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		ChannelName:       options.ChannelName,
 		ChaincodeName:     options.ChaincodeName,
 		CustomPinSupport:  options.CustomPinSupport,
+		RemoteNodeDeploy:  options.RemoteNodeDeploy,
 	}
 
 	tokenProviders, err := types.FFEnumArray(s.ctx, options.TokenProviders)

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -1,4 +1,4 @@
-// Copyright © 2022 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -63,6 +63,7 @@ type InitOptions struct {
 	ChannelName              string
 	ChaincodeName            string
 	CustomPinSupport         bool
+	RemoteNodeDeploy         bool
 }
 
 const IPFSMode = "ipfs_mode"

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -1,4 +1,4 @@
-// Copyright © 2021 Kaleido, Inc.
+// Copyright © 2023 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -49,6 +49,7 @@ type Stack struct {
 	ChannelName            string           `json:"channelName,omitempty"`
 	ChaincodeName          string           `json:"chaincodeName,omitempty"`
 	CustomPinSupport       bool             `json:"customPinSupport,omitempty"`
+	RemoteNodeDeploy       bool             `json:"remoteNodeDeploy,omitempty"`
 	InitDir                string           `json:"-"`
 	RuntimeDir             string           `json:"-"`
 	StackDir               string           `json:"-"`


### PR DESCRIPTION
Specifically, this option allows the `ff init` command to be run with `-n remote-rpc` without specifying `--contract-address`, something which was previously not supported.

By default the CLI will behave the same as previous versions. However, setting the new `--remote-node-deploy=true` option will perform both the deployment of the FireFly contract, and the identity/org registration. Effectively this option is a way of saying "the remote node is a free-gas chain", but I thought it might be possible to use for non-free-gas chains such as Polygon, if you had a way of ensuring your signing key had enough gas to pay for the deployment. Hence calling the new option `--remote-node-deploy`, not `--remote-node-free-gas` or similar.