### PR TITLE
Fix checking result of queryInstalled()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
 
 permissions:
@@ -15,19 +15,16 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,9 +32,8 @@ archives:
       {{ .ProjectName }}_
       {{- if eq .Os "darwin" }}macOS
       {{- else if eq .Arch "linux" }}Linux
-      {{- else }}{{ .Os }}{{ end }}
+      {{- else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,19 +28,23 @@ builds:
     ldflags:
       - "-s -w -X 'github.com/hyperledger/firefly-cli/cmd.BuildVersionOverride={{.Version}}' -X 'github.com/hyperledger/firefly-cli/cmd.BuildDate={{.Date}}' -X 'github.com/hyperledger/firefly-cli/cmd.BuildCommit={{.Commit}}'"
 archives:
-  - replacements:
-      darwin: macOS
-      linux: Linux
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- if eq .Os "darwin" }}macOS
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else }}{{ .Os }}{{ end }}
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Tag }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 release:
   prerelease: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,9 @@ builds:
 archives:
   - name_template: >-
       {{ .ProjectName }}_
+      {{ .Version }}_
       {{- if eq .Os "darwin" }}macOS
-      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Os "linux" }}Linux
       {{- else }}{{ .Os }}{{ end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{ end }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,7 @@ builds:
       - "-s -w -X 'github.com/hyperledger/firefly-cli/cmd.BuildVersionOverride={{.Version}}' -X 'github.com/hyperledger/firefly-cli/cmd.BuildDate={{.Date}}' -X 'github.com/hyperledger/firefly-cli/cmd.BuildCommit={{.Commit}}'"
 archives:
   - name_template: >-
-      {{ .ProjectName }}_
-      {{ .Version }}_
+      {{ .ProjectName }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}macOS
       {{- else if eq .Os "linux" }}Linux
       {{- else }}{{ .Os }}{{ end }}_

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 
 	"github.com/hyperledger/firefly-cli/internal/blockchain/fabric/fabconnect"
 	"github.com/hyperledger/firefly-cli/internal/docker"
@@ -543,7 +544,9 @@ func (p *FabricProvider) DeployContract(filename, contractName, instanceName str
 	chaincodeInstalled := false
 	packageID := ""
 	for _, installedChaincode := range res.InstalledChaincodes {
-		if installedChaincode.Label == chaincode {
+		validLabel := regexp.MustCompile(`^([^_]+)_.+$`)
+		matches := validLabel.FindStringSubmatch(installedChaincode.Label)
+		if len(matches) > 0 && matches[1] == chaincode {
 			chaincodeInstalled = true
 			packageID = installedChaincode.PackageID
 			break


### PR DESCRIPTION
the `label` property has the value that is a combination of the chaincode name version. for instance if the chaincode name is `basic`, and version is `v2.0`, then the label is returned as `basic_v2.0`, using the convention `_` to concatenate the two parts:

```
{
	"installed_chaincodes": [
		{
			"package_id": "firefly_1.0:b8e754685421dd03e40251b9ef2dd811e49659453cd489ca7bd27585d9be06b4",
			"label": "firefly_1.0",
			"references": {
				"firefly": {
					"chaincodes": [
						{
							"name": "firefly",
							"version": "1.0"
						}
					]
				}
			}
		},
		{
			"package_id": "basic_v1.0:351b39eb21c6a1d42f65d21398bf747880404c322a8883f2fb61fe1a3bb0d68d",
			"label": "basic_v1.0"
		}
	]
}
```