### PR TITLE
Separate build and release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
-name: Build
+name: build
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -21,5 +20,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: Compile FireFly CLI
-        run: make
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Apparently Goreleaser is now picky about doing builds against commits that don't match the tag that it's expecting. The version of Goreleaser that we're using was recently upgraded which caused this change. Previously, (I'm not sure why) we were running Goreleaser on every PR whether we were doing a release or not. This PR separates the jobs and just runs `make` on PRs and will run `goreleaser` anytime we tag a new release. This should unblock our PR backlog.