### PR TITLE
Separate build and release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,16 @@
-name: build
+name: Build
 
 on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
   pull_request:
 
 permissions:
   contents: write
 
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,11 +21,5 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compile FireFly CLI
+        run: make

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: build
+name: E2E
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
-      
+
       - name: Compile FireFly CLI
         working-directory: firefly-cli
         run: make install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Apparently Goreleaser is now picky about doing builds against commits that don't match the tag that it's expecting. The version of Goreleaser that we're using was recently upgraded which caused this change. Previously, (I'm not sure why) we were running Goreleaser on every PR whether we were doing a release or not. This PR separates the jobs and just runs make on PRs and will run goreleaser anytime we tag a new release. This should unblock our PR backlog.