### PR TITLE
feature: upgrade the Fabric version to v2.5 TLS

### DIFF
--- a/internal/blockchain/fabric/constants.go
+++ b/internal/blockchain/fabric/constants.go
@@ -16,7 +16,7 @@
 
 package fabric
 
-var FabricToolsImageName = "hyperledger/fabric-tools:2.3"
+var FabricToolsImageName = "hyperledger/fabric-tools:2.5"
 var FabricCAImageName = "hyperledger/fabric-ca:1.5"
-var FabricOrdererImageName = "hyperledger/fabric-orderer:2.3"
-var FabricPeerImageName = "hyperledger/fabric-peer:2.3"
+var FabricOrdererImageName = "hyperledger/fabric-orderer:2.5"
+var FabricPeerImageName = "hyperledger/fabric-peer:2.5"

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -124,7 +124,7 @@ func (p *FabricProvider) FirstTimeSetup() error {
 			"--platform", getDockerPlatform(),
 			"--rm",
 			"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
-			"-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
+			"-v", fmt.Sprintf("%s:/var/hyperledger/fabric/config/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
 			FabricToolsImageName,
 			"configtxgen",
 			"-outputBlock", "/etc/firefly/firefly.block",


### PR DESCRIPTION
Related to: #https://github.com/hyperledger/firefly-cli/issues/268

I've run the E2E tests locally as @nguyer mentioned:
`DOWNLOAD_CLI=false STACK_TYPE=fabric TEST_SUITE=TestFabricMultipartyE2ESuite  MULTIPARTY_ENABLED=true  ./run.sh`

--- PASS: TestFabricMultipartyE2ESuite (137.02s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EBroadcast (3.97s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EBroadcastBlob (34.51s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EPrivate (3.74s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EPrivateBlobDatatypeTagged (3.71s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EWebhookExchange (7.61s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EWebhookRequestReplyNoTx (4.78s)
    --- PASS: TestFabricMultipartyE2ESuite/TestStrongDatatypesBroadcast (7.58s)
    --- PASS: TestFabricMultipartyE2ESuite/TestStrongDatatypesPrivate (7.29s)
    --- PASS: TestFabricMultipartyE2ESuite/TestCustomChildIdentityBroadcasts (7.88s)
    --- PASS: TestFabricMultipartyE2ESuite/TestCustomChildIdentityPrivate (11.26s)
    --- PASS: TestFabricMultipartyE2ESuite/TestInvalidIdentityAlreadyRegistered (9.39s)
    --- PASS: TestFabricMultipartyE2ESuite/TestE2EContractEvents (2.69s)
PASS
ok  	github.com/hyperledger/firefly/test/e2e/runners	137.028s

But some changes are needed in Firefly main project also. I added those in the PR: #https://github.com/hyperledger/firefly/pull/1415