### PR TITLE
Remove remote-node-url since connector info provided by tezosconnect.yml

### DIFF
--- a/cmd/init_tezos.go
+++ b/cmd/init_tezos.go
@@ -60,8 +60,8 @@ var initTezosCmd = &cobra.Command{
 }
 
 func validateTezosFlags() error {
-	if initOptions.RemoteNodeURL == "" {
-		return fmt.Errorf("you must provide 'remote-node-url' flag as local node mode is not supported")
+	if initOptions.ExtraConnectorConfigPath == "" {
+		return fmt.Errorf("you must provide 'connector-config' flag with path to 'tezosconnect.yml' config file")
 	}
 	return nil
 }
@@ -69,7 +69,6 @@ func validateTezosFlags() error {
 func init() {
 	initTezosCmd.Flags().IntVar(&initOptions.BlockPeriod, "block-period", -1, "Block period in seconds. Default is variable based on selected blockchain provider.")
 	initTezosCmd.Flags().StringVar(&initOptions.ContractAddress, "contract-address", "", "Do not automatically deploy a contract, instead use a pre-configured address")
-	initTezosCmd.Flags().StringVar(&initOptions.RemoteNodeURL, "remote-node-url", "", "For cases where the node is pre-existing and running remotely")
 
 	initCmd.AddCommand(initTezosCmd)
 }

--- a/internal/blockchain/tezos/connector/connector_interface.go
+++ b/internal/blockchain/tezos/connector/connector_interface.go
@@ -23,7 +23,7 @@ import (
 
 type Connector interface {
 	GetServiceDefinitions(s *types.Stack, dependentServices map[string]string) []*docker.ServiceDefinition
-	GenerateConfig(stack *types.Stack, member *types.Organization, signerHostname, rpcURL string) Config
+	GenerateConfig(stack *types.Stack, member *types.Organization, signerHostname string) Config
 	Name() string
 	Port() int
 }

--- a/internal/blockchain/tezos/connector/tezosconnect/config.go
+++ b/internal/blockchain/tezos/connector/tezosconnect/config.go
@@ -19,7 +19,6 @@ package tezosconnect
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/hyperledger/firefly-cli/internal/blockchain/tezos/connector"
 	"github.com/hyperledger/firefly-cli/pkg/types"
@@ -91,7 +90,7 @@ func (c *Config) WriteConfig(filename string, extraTezosconnectConfigPath string
 	return nil
 }
 
-func (t *Tezosconnect) GenerateConfig(stack *types.Stack, org *types.Organization, signerHostname, rpcURL string) connector.Config {
+func (t *Tezosconnect) GenerateConfig(stack *types.Stack, org *types.Organization, signerHostname string) connector.Config {
 	confirmations := new(int)
 	*confirmations = 0
 	var metrics *types.MetricsServerConfig
@@ -110,11 +109,6 @@ func (t *Tezosconnect) GenerateConfig(stack *types.Stack, org *types.Organizatio
 		metrics = nil
 	}
 
-	network := "mainnet"
-	if strings.Contains(rpcURL, "ghost") {
-		network = "ghostnet"
-	}
-
 	return &Config{
 		Log: &types.LogConfig{
 			Level: "debug",
@@ -123,13 +117,6 @@ func (t *Tezosconnect) GenerateConfig(stack *types.Stack, org *types.Organizatio
 			Port:      t.Port(),
 			Address:   "0.0.0.0",
 			PublicURL: fmt.Sprintf("http://127.0.0.1:%v", org.ExposedConnectorPort),
-		},
-		Connector: &ConnectorConfig{
-			Blockchain: &BlockchainConfig{
-				Network:   network,
-				RPC:       rpcURL,
-				Signatory: fmt.Sprintf("http://%s:6732", signerHostname),
-			},
 		},
 		Persistence: &PersistenceConfig{
 			LevelDB: &LevelDBConfig{

--- a/internal/blockchain/tezos/remoterpc/remoterpc_provider.go
+++ b/internal/blockchain/tezos/remoterpc/remoterpc_provider.go
@@ -53,7 +53,7 @@ func (p *RemoteRPCProvider) WriteConfig(options *types.InitOptions) error {
 	for i, member := range p.stack.Members {
 		// Generate the connector config for each member
 		connectorConfigPath := filepath.Join(initDir, "config", fmt.Sprintf("%s_%v.yaml", p.connector.Name(), i))
-		if err := p.connector.GenerateConfig(p.stack, member, "tezossigner", options.RemoteNodeURL).WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
+		if err := p.connector.GenerateConfig(p.stack, member, "tezossigner").WriteConfig(connectorConfigPath, options.ExtraConnectorConfigPath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently remote-node-url is required, but accordance to https://github.com/hyperledger/firefly/blob/4645f28a17f6ad813d0a9cbb39ba07d2a5cca795/docs/tutorials/chains/tezos_testnet.md?plain=1#L33C14-L33C30 we should provide tezosconnect.yml in which we have the same section. So left only section from config   

^^ @denisandreenko 