### PR TITLE
Limit upgrade command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -114,7 +115,10 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Println(err.Error())
+		var e viper.ConfigFileNotFoundError
+		if !errors.As(err, &e) {
+			fmt.Println(err.Error())
+		}
 	}
 
 }

--- a/internal/core/manifest.go
+++ b/internal/core/manifest.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hyperledger/firefly-cli/internal/constants"
 	"github.com/hyperledger/firefly-cli/internal/docker"
@@ -122,4 +123,21 @@ func ReadManifestFile(p string) (*types.VersionManifest, error) {
 		}
 	}
 	return manifest, err
+}
+
+func ValidateVersionUpgrade(oldVersion, newVersion string) error {
+	oldSemVer := strings.Split(strings.Trim(oldVersion, "v"), ".")
+	newSemVer := strings.Split(strings.Trim(newVersion, "v"), ".")
+	if len(oldSemVer) < 3 || len(newSemVer) < 3 {
+		return fmt.Errorf("FireFly CLI only supports updating local development environments between patch versions")
+	}
+	// Only upgrading between patch versions is supported
+	// e.g. 1.3.0 -> 1.3.1
+	if oldSemVer[0] == newSemVer[0] && oldSemVer[1] == newSemVer[1] {
+		if oldSemVer[2] > newSemVer[2] {
+			return fmt.Errorf("FireFly CLI does not support downgrading local development environments")
+		}
+		return nil
+	}
+	return fmt.Errorf("FireFly CLI only supports updating local development environments between patch versions")
 }

--- a/internal/core/manifest_test.go
+++ b/internal/core/manifest_test.go
@@ -45,3 +45,14 @@ func TestGetLatestReleaseManifest(t *testing.T) {
 	assert.NotNil(t, manifest.TokensERC1155)
 	assert.NotNil(t, manifest.TokensERC20ERC721)
 }
+
+func TestIsSupportedVersionUpgrade(t *testing.T) {
+	assert.NoError(t, ValidateVersionUpgrade("v1.2.1", "v1.2.2"))
+	assert.NoError(t, ValidateVersionUpgrade("v1.2.0", "v1.2.2"))
+	assert.NoError(t, ValidateVersionUpgrade("1.2.1", "v1.2.2"))
+	assert.NoError(t, ValidateVersionUpgrade("v1.2.1", "1.2.2"))
+
+	assert.Error(t, ValidateVersionUpgrade("v1.2.2", "v1.3.0"))
+	assert.Error(t, ValidateVersionUpgrade("latest", "v1.3.0"))
+	assert.Error(t, ValidateVersionUpgrade("v1.2.2", "latest"))
+}


### PR DESCRIPTION
The existing upgrade command is pretty limited in what it is able to do. It simply rewrites the stack.json and docker-compose file with newer image tags from a different version manifest. If there is any additional migration (such as config changes) required between versions it will not work.

As an example, when we moved all of the containers to run as a non-root user the FireFly CLI also had to be updated to put config files in a different location which a non-root user could read. This change was _backward_ compatible with older versions of FireFly, but older versions of the CLI would not be able to generate the proper config for _newer_ versions of FireFly. Thus, simply swapping the image tag would not work to move from 1.2.x -> 1.3.x because of permissions changes.

This PR sets some guardrails on the upgrade command to allow it to apply patch releases only (which should not contain these types of changes), and does not allow downgrades.