### PR TITLE
Fix fabric-tools and update E2E matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,64 +7,110 @@ permissions:
   contents: write
 
 jobs:
-  e2e-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test-suite: [TestEthereumE2ESuite, TestFabricE2ESuite]
-        blockchain-provider: [geth, fabric, besu]
-        token-provider: [none, erc1155, erc20_erc721]
-        database-type: [sqlite3, postgres]
-        exclude:
-          - blockchain-provider: geth
-            test-suite: TestFabricE2ESuite
-          - blockchain-provider: besu
-            test-suite: TestFabricE2ESuite
-          - blockchain-provider: fabric
-            test-suite: TestEthereumE2ESuite
-          - blockchain-provider: fabric
-            token-provider: erc1155
-          - blockchain-provider: fabric
-            token-provider: erc20_erc721
-          - blockchain-provider: geth
-            token-provider: none
-          - blockchain-provider: besu
-            token-provider: none
-      fail-fast: false
-    steps:
-      - name: Checkout FireFly CLI
-        uses: actions/checkout@v4
-        with:
-          path: firefly-cli
-          fetch-depth: 0
-      - name: Checkout FireFly Core repo
-        uses: actions/checkout@v4
-        with:
-          repository: hyperledger/firefly
-          path: firefly
+  runs-on: ubuntu-latest
+  needs: docker
+  strategy:
+    fail-fast: false
+    matrix:
+      stack-type: [ethereum, fabric]
+      exclude: [stack-type: ethereum, stack-type: fabric]
+      include:
+        - stack-type: ethereum
+          blockchain-connector: evmconnect
+          test-suite: TestEthereumMultipartyE2ESuite
+          database-type: sqlite3
+          token-provider: erc20_erc721
+          multiparty-enabled: true
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
+        - stack-type: ethereum
+          blockchain-connector: evmconnect
+          test-suite: TestEthereumMultipartyE2ESuite
+          database-type: postgres
+          token-provider: erc20_erc721
+          multiparty-enabled: true
 
-      - name: Compile FireFly CLI
-        working-directory: firefly-cli
-        run: make install
+        - stack-type: ethereum
+          blockchain-connector: evmconnect
+          test-suite: TestEthereumMultipartyE2ESuite
+          database-type: sqlite3
+          token-provider: erc1155
+          multiparty-enabled: true
 
-      - name: Run E2E tests
-        working-directory: firefly
-        env:
-          TEST_SUITE: ${{ matrix.test-suite }}
-          BLOCKCHAIN_PROVIDER: ${{ matrix.blockchain-provider }}
-          TOKENS_PROVIDER: ${{ matrix.token-provider }}
-          DATABASE_TYPE: ${{ matrix.database-type }}
-          DOWNLOAD_CLI: false
-        run: ./test/e2e/run.sh
+        - stack-type: ethereum
+          blockchain-connector: evmconnect
+          test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
+          database-type: postgres
+          token-provider: erc20_erc721
+          multiparty-enabled: true
 
-      - name: Archive container logs
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-provider }}-${{ matrix.database-type }}-${{ matrix.token-provider }}
-          path: containerlogs/logs.txt
+        - stack-type: fabric
+          test-suite: TestFabricE2ESuite
+          database-type: sqlite3
+          token-provider: none
+          multiparty-enabled: true
+
+        - stack-type: ethereum
+          blockchain-connector: evmconnect
+          test-suite: TestEthereumGatewayE2ESuite
+          database-type: sqlite3
+          token-provider: erc20_erc721
+          multiparty-enabled: false
+
+        - stack-type: fabric
+          test-suite: TestFabricGatewayE2ESuite
+          database-type: sqlite3
+          token-provider: none
+          multiparty-enabled: false
+
+        - stack-type: ethereum
+          blockchain-connector: ethconnect
+          test-suite: TestEthereumMultipartyE2ESuite
+          database-type: sqlite3
+          token-provider: erc20_erc721
+          multiparty-enabled: true
+
+        - stack-type: ethereum
+          blockchain-connector: ethconnect
+          test-suite: TestEthereumGatewayLegacyEthE2ESuite
+          database-type: sqlite3
+          token-provider: erc1155
+          multiparty-enabled: false
+
+  steps:
+    - name: Checkout FireFly CLI
+      uses: actions/checkout@v4
+      with:
+        path: firefly-cli
+        fetch-depth: 0
+    - name: Checkout FireFly Core repo
+      uses: actions/checkout@v4
+      with:
+        repository: hyperledger/firefly
+        path: firefly
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: "1.21"
+
+    - name: Compile FireFly CLI
+      working-directory: firefly-cli
+      run: make install
+
+    - name: Run E2E tests
+      working-directory: firefly
+      env:
+        TEST_SUITE: ${{ matrix.test-suite }}
+        STACK_TYPE: ${{ matrix.stack-type }}
+        BLOCKCHAIN_CONNECTOR: ${{ matrix.blockchain-connector }}
+        TOKENS_PROVIDER: ${{ matrix.token-provider }}
+        DATABASE_TYPE: ${{ matrix.database-type }}
+        MULTIPARTY_ENABLED: ${{ matrix.multiparty-enabled }}
+      run: ./test/e2e/run.sh
+
+    - name: Archive container logs
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-provider }}-${{ matrix.blockchain-connector }}-${{ matrix.database-type }}-${{ matrix.token-provider }}
+        path: containerlogs/logs.txt

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,74 +7,75 @@ permissions:
   contents: write
 
 jobs:
-  runs-on: ubuntu-latest
-  needs: docker
-  strategy:
-    fail-fast: false
-    matrix:
-      stack-type: [ethereum, fabric]
-      exclude: [stack-type: ethereum, stack-type: fabric]
-      include:
-        - stack-type: ethereum
-          blockchain-connector: evmconnect
-          test-suite: TestEthereumMultipartyE2ESuite
-          database-type: sqlite3
-          token-provider: erc20_erc721
-          multiparty-enabled: true
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: docker
+    strategy:
+      fail-fast: false
+      matrix:
+        stack-type: [ethereum, fabric]
+        exclude: [stack-type: ethereum, stack-type: fabric]
+        include:
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-        - stack-type: ethereum
-          blockchain-connector: evmconnect
-          test-suite: TestEthereumMultipartyE2ESuite
-          database-type: postgres
-          token-provider: erc20_erc721
-          multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: postgres
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-        - stack-type: ethereum
-          blockchain-connector: evmconnect
-          test-suite: TestEthereumMultipartyE2ESuite
-          database-type: sqlite3
-          token-provider: erc1155
-          multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc1155
+            multiparty-enabled: true
 
-        - stack-type: ethereum
-          blockchain-connector: evmconnect
-          test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
-          database-type: postgres
-          token-provider: erc20_erc721
-          multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumMultipartyTokensRemoteNameE2ESuite
+            database-type: postgres
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-        - stack-type: fabric
-          test-suite: TestFabricE2ESuite
-          database-type: sqlite3
-          token-provider: none
-          multiparty-enabled: true
+          - stack-type: fabric
+            test-suite: TestFabricE2ESuite
+            database-type: sqlite3
+            token-provider: none
+            multiparty-enabled: true
 
-        - stack-type: ethereum
-          blockchain-connector: evmconnect
-          test-suite: TestEthereumGatewayE2ESuite
-          database-type: sqlite3
-          token-provider: erc20_erc721
-          multiparty-enabled: false
+          - stack-type: ethereum
+            blockchain-connector: evmconnect
+            test-suite: TestEthereumGatewayE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: false
 
-        - stack-type: fabric
-          test-suite: TestFabricGatewayE2ESuite
-          database-type: sqlite3
-          token-provider: none
-          multiparty-enabled: false
+          - stack-type: fabric
+            test-suite: TestFabricGatewayE2ESuite
+            database-type: sqlite3
+            token-provider: none
+            multiparty-enabled: false
 
-        - stack-type: ethereum
-          blockchain-connector: ethconnect
-          test-suite: TestEthereumMultipartyE2ESuite
-          database-type: sqlite3
-          token-provider: erc20_erc721
-          multiparty-enabled: true
+          - stack-type: ethereum
+            blockchain-connector: ethconnect
+            test-suite: TestEthereumMultipartyE2ESuite
+            database-type: sqlite3
+            token-provider: erc20_erc721
+            multiparty-enabled: true
 
-        - stack-type: ethereum
-          blockchain-connector: ethconnect
-          test-suite: TestEthereumGatewayLegacyEthE2ESuite
-          database-type: sqlite3
-          token-provider: erc1155
-          multiparty-enabled: false
+          - stack-type: ethereum
+            blockchain-connector: ethconnect
+            test-suite: TestEthereumGatewayLegacyEthE2ESuite
+            database-type: sqlite3
+            token-provider: erc1155
+            multiparty-enabled: false
 
   steps:
     - name: Checkout FireFly CLI

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,41 +77,41 @@ jobs:
             token-provider: erc1155
             multiparty-enabled: false
 
-  steps:
-    - name: Checkout FireFly CLI
-      uses: actions/checkout@v4
-      with:
-        path: firefly-cli
-        fetch-depth: 0
-    - name: Checkout FireFly Core repo
-      uses: actions/checkout@v4
-      with:
-        repository: hyperledger/firefly
-        path: firefly
+    steps:
+      - name: Checkout FireFly CLI
+        uses: actions/checkout@v4
+        with:
+          path: firefly-cli
+          fetch-depth: 0
+      - name: Checkout FireFly Core repo
+        uses: actions/checkout@v4
+        with:
+          repository: hyperledger/firefly
+          path: firefly
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: "1.21"
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
 
-    - name: Compile FireFly CLI
-      working-directory: firefly-cli
-      run: make install
+      - name: Compile FireFly CLI
+        working-directory: firefly-cli
+        run: make install
 
-    - name: Run E2E tests
-      working-directory: firefly
-      env:
-        TEST_SUITE: ${{ matrix.test-suite }}
-        STACK_TYPE: ${{ matrix.stack-type }}
-        BLOCKCHAIN_CONNECTOR: ${{ matrix.blockchain-connector }}
-        TOKENS_PROVIDER: ${{ matrix.token-provider }}
-        DATABASE_TYPE: ${{ matrix.database-type }}
-        MULTIPARTY_ENABLED: ${{ matrix.multiparty-enabled }}
-      run: ./test/e2e/run.sh
+      - name: Run E2E tests
+        working-directory: firefly
+        env:
+          TEST_SUITE: ${{ matrix.test-suite }}
+          STACK_TYPE: ${{ matrix.stack-type }}
+          BLOCKCHAIN_CONNECTOR: ${{ matrix.blockchain-connector }}
+          TOKENS_PROVIDER: ${{ matrix.token-provider }}
+          DATABASE_TYPE: ${{ matrix.database-type }}
+          MULTIPARTY_ENABLED: ${{ matrix.multiparty-enabled }}
+        run: ./test/e2e/run.sh
 
-    - name: Archive container logs
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-provider }}-${{ matrix.blockchain-connector }}-${{ matrix.database-type }}-${{ matrix.token-provider }}
-        path: containerlogs/logs.txt
+      - name: Archive container logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: container-logs-${{ matrix.test-suite }}-${{ matrix.blockchain-provider }}-${{ matrix.blockchain-connector }}-${{ matrix.database-type }}-${{ matrix.token-provider }}
+          path: containerlogs/logs.txt

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,6 @@ permissions:
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
-    needs: docker
     strategy:
       fail-fast: false
       matrix:

--- a/internal/blockchain/fabric/constants.go
+++ b/internal/blockchain/fabric/constants.go
@@ -16,7 +16,7 @@
 
 package fabric
 
-var FabricToolsImageName = "hyperledger/fabric-tools:2.5"
+var FabricToolsImageName = "hyperledger/fabric-tools:2.5.6"
 var FabricCAImageName = "hyperledger/fabric-ca:1.5"
 var FabricOrdererImageName = "hyperledger/fabric-orderer:2.5"
 var FabricPeerImageName = "hyperledger/fabric-peer:2.5"

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -126,7 +126,7 @@ func (p *FabricProvider) FirstTimeSetup() error {
 			"--platform", getDockerPlatform(),
 			"--rm",
 			"-v", fmt.Sprintf("%s:/etc/firefly", volumeName),
-			"-v", fmt.Sprintf("%s:/var/hyperledger/fabric/config/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
+			"-v", fmt.Sprintf("%s:/etc/hyperledger/fabric/configtx.yaml", path.Join(blockchainDirectory, "configtx.yaml")),
 			FabricToolsImageName,
 			"configtxgen",
 			"-outputBlock", "/etc/firefly/firefly.block",


### PR DESCRIPTION
I discovered that despite some of the job labels, all of the jobs in the matrix ended up testing the same type of stack. This PR brings the E2E matrix into alignment with the same set of tests we run in the FireFly Core repo.