### PR TITLE
Fix Besu genesis

### DIFF
--- a/internal/blockchain/ethereum/besu/genesis.go
+++ b/internal/blockchain/ethereum/besu/genesis.go
@@ -79,7 +79,7 @@ func CreateGenesis(addresses []string, blockPeriod int, chainID int64) *Genesis 
 		alloc[address] = &Alloc{
 			Balance: "0x200000000000000000000000000000000000000000000000000000000000000",
 		}
-		extraData += extraData
+		extraData += address
 	}
 	extraData = strings.ReplaceAll(fmt.Sprintf("%-236s", extraData), " ", "0")
 	return &Genesis{

--- a/internal/blockchain/ethereum/besu/genesis_test.go
+++ b/internal/blockchain/ethereum/besu/genesis_test.go
@@ -48,7 +48,7 @@ func TestCreateGenesis(t *testing.T) {
 				alloc[address] = &Alloc{
 					Balance: "0x200000000000000000000000000000000000000000000000000000000000000",
 				}
-				extraData += extraData
+				extraData += address
 			}
 			extraData = strings.ReplaceAll(fmt.Sprintf("%-236s", extraData), " ", "0")
 			expectedGenesis := &Genesis{


### PR DESCRIPTION
The Besu genesis.json was getting created with an invalid extraData field which was causing it to fail to start up. This PR fixes that issue.