### PR TITLE
Add `--force` flag to upgrade. Fix `deploy fabric` command.

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var forceUpgrade bool
+
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade <stack_name> <version>",
 	Short: "Upgrade a stack to different version",
@@ -66,7 +68,7 @@ var upgradeCmd = &cobra.Command{
 			return err
 		}
 		fmt.Printf("upgrading stack '%s'... ", stackName)
-		if err := stackManager.UpgradeStack(version); err != nil {
+		if err := stackManager.UpgradeStack(version, forceUpgrade); err != nil {
 			return err
 		}
 		fmt.Printf("\n\nYour stack has been upgraded to %s\n\nTo start your upgraded stack run:\n\n%s start %s\n\n", version, rootCmd.Use, stackName)
@@ -75,5 +77,6 @@ var upgradeCmd = &cobra.Command{
 }
 
 func init() {
+	upgradeCmd.Flags().BoolVarP(&forceUpgrade, "force", "f", false, "Force upgrade even between unsupported versions. May result in a broken environment. Use with caution.")
 	rootCmd.AddCommand(upgradeCmd)
 }

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/hyperledger/firefly-cli/internal/blockchain/fabric/fabconnect"
 	"github.com/hyperledger/firefly-cli/internal/docker"
@@ -395,6 +396,9 @@ func (p *FabricProvider) extractChaincode() error {
 func (p *FabricProvider) installChaincode(packageFilename string) error {
 	p.log.Info("installing chaincode")
 	contractsDir := path.Join(p.stack.RuntimeDir, "contracts")
+	if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
+		os.Mkdir(contractsDir, 0755)
+	}
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.stack.Name)
 	return docker.RunDockerCommand(p.ctx, contractsDir,
 		"run",
@@ -534,7 +538,9 @@ func (p *FabricProvider) DeployContract(filename, contractName, instanceName str
 	version := extraArgs[2]
 
 	if err := p.installChaincode(filename); err != nil {
-		return nil, err
+		if !strings.Contains(err.Error(), "chaincode already successfully installed") {
+			return nil, err
+		}
 	}
 
 	res, err := p.queryInstalled()
@@ -547,10 +553,12 @@ func (p *FabricProvider) DeployContract(filename, contractName, instanceName str
 	for _, installedChaincode := range res.InstalledChaincodes {
 		validLabel := regexp.MustCompile(`^([^_]+)_.+$`)
 		matches := validLabel.FindStringSubmatch(installedChaincode.Label)
-		if len(matches) > 0 && matches[1] == chaincode {
-			chaincodeInstalled = true
-			packageID = installedChaincode.PackageID
-			break
+		for _, match := range matches {
+			if match == chaincode {
+				chaincodeInstalled = true
+				packageID = installedChaincode.PackageID
+				break
+			}
 		}
 	}
 

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -397,7 +397,9 @@ func (p *FabricProvider) installChaincode(packageFilename string) error {
 	p.log.Info("installing chaincode")
 	contractsDir := path.Join(p.stack.RuntimeDir, "contracts")
 	if _, err := os.Stat(contractsDir); os.IsNotExist(err) {
-		os.Mkdir(contractsDir, 0755)
+		if err := os.Mkdir(contractsDir, 0755); err != nil {
+			return err
+		}
 	}
 	volumeName := fmt.Sprintf("%s_firefly_fabric", p.stack.Name)
 	return docker.RunDockerCommand(p.ctx, contractsDir,

--- a/internal/stacks/prometheus_config.go
+++ b/internal/stacks/prometheus_config.go
@@ -1,3 +1,19 @@
+// Copyright © 2024 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stacks
 
 import "fmt"

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -1065,7 +1065,7 @@ func (s *StackManager) waitForFireflyStart(port int) error {
 	return fmt.Errorf("waited for %v seconds for firefly to start on port %v but it was never available", retries*retryPeriod/1000, port)
 }
 
-func (s *StackManager) UpgradeStack(version string) error {
+func (s *StackManager) UpgradeStack(version string, forceUpgrade bool) error {
 	// stop the currently running stack
 	if err := s.StopStack(); err != nil {
 		return err
@@ -1076,8 +1076,10 @@ func (s *StackManager) UpgradeStack(version string) error {
 		return err
 	}
 
-	if err := core.ValidateVersionUpgrade(oldVersion, version); err != nil {
-		return err
+	if !forceUpgrade {
+		if err := core.ValidateVersionUpgrade(oldVersion, version); err != nil {
+			return err
+		}
 	}
 
 	// get the version manifest for the new version


### PR DESCRIPTION
This PR adds a `--force` flag to the upgrade command to allow upgrades between unsupported versions. This is useful to me in migration testing when I know how to "hack" around the reasons that the upgrade may have been unsupported.

This PR also fixes a few issues with deploying custom chaincode to Fabric networks.

Resolves https://github.com/hyperledger/firefly-cli/issues/297