### PR TITLE
Add environment vars cli flag to stack init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -271,5 +271,6 @@ func init() {
 	initCmd.PersistentFlags().StringArrayVar(&initOptions.OrgNames, "org-name", []string{}, "Organization name")
 	initCmd.PersistentFlags().StringArrayVar(&initOptions.NodeNames, "node-name", []string{}, "Node name")
 	initCmd.PersistentFlags().BoolVar(&initOptions.RemoteNodeDeploy, "remote-node-deploy", false, "Enable or disable deployment of FireFly contracts on remote nodes")
+	initCmd.PersistentFlags().StringToStringVar(&initOptions.EnvironmentVars, "environment-vars", map[string]string{}, "Common environment variables to set on all containers in FireFly stack")
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/blockchain/ethereum/besu/besu_provider.go
+++ b/internal/blockchain/ethereum/besu/besu_provider.go
@@ -172,7 +172,8 @@ func (p *BesuProvider) GetDockerServiceDefinitions() []*docker.ServiceDefinition
 			Volumes: []string{
 				"besu:/data",
 			},
-			Logging: docker.StandardLogOptions,
+			Logging:     docker.StandardLogOptions,
+			Environment: p.stack.EnvironmentVars,
 		},
 
 		VolumeNames: []string{"besu"},

--- a/internal/blockchain/ethereum/connector/ethconnect/docker.go
+++ b/internal/blockchain/ethereum/connector/ethconnect/docker.go
@@ -42,7 +42,8 @@ func (e *Ethconnect) GetServiceDefinitions(s *types.Stack, dependentServices map
 					fmt.Sprintf("ethconnect_config_%s:/ethconnect/config", member.ID),
 					fmt.Sprintf("ethconnect_data_%s:/ethconnect/data", member.ID),
 				},
-				Logging: docker.StandardLogOptions,
+				Logging:     docker.StandardLogOptions,
+				Environment: s.EnvironmentVars,
 			},
 			VolumeNames: []string{
 				fmt.Sprintf("ethconnect_config_%v", member.ID),

--- a/internal/blockchain/ethereum/connector/ethconnect/docker_test.go
+++ b/internal/blockchain/ethereum/connector/ethconnect/docker_test.go
@@ -75,6 +75,19 @@ func TestGetServiceDefinition(t *testing.T) {
 			},
 			ServiceName: "ethconnect_firefly_4",
 		},
+		{
+			Name: "test_env_vars_5",
+			Members: &types.Stack{
+				Members:         []*types.Organization{{ID: "firefly_5", ExposedConnectorPort: 7892}},
+				VersionManifest: &types.VersionManifest{Ethconnect: &getManifest.ManifestEntry},
+				EnvironmentVars: map[string]interface{}{"HTTP_PROXY": ""},
+			},
+			DependentServices: map[string]string{
+				"service1": "running",
+				"service2": "stopped",
+			},
+			ServiceName: "ethconnect_firefly_5",
+		},
 	}
 	for _, tc := range testServices {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/internal/blockchain/ethereum/connector/evmconnect/docker.go
+++ b/internal/blockchain/ethereum/connector/evmconnect/docker.go
@@ -43,7 +43,8 @@ func (e *Evmconnect) GetServiceDefinitions(s *types.Stack, dependentServices map
 					fmt.Sprintf("%s/config/evmconnect_%s.yaml:/evmconnect/config.yaml", s.RuntimeDir, member.ID),
 					fmt.Sprintf("%s:/evmconnect/data", dataVolumeName),
 				},
-				Logging: docker.StandardLogOptions,
+				Logging:     docker.StandardLogOptions,
+				Environment: s.EnvironmentVars,
 			},
 			VolumeNames: []string{
 				dataVolumeName,

--- a/internal/blockchain/ethereum/connector/evmconnect/docker_test.go
+++ b/internal/blockchain/ethereum/connector/evmconnect/docker_test.go
@@ -75,6 +75,19 @@ func TestGetServiceDefinition(t *testing.T) {
 			},
 			ServiceName: "evmconnect_firefly_4",
 		},
+		{
+			Name: "test_env_vars_5",
+			Members: &types.Stack{
+				Members:         []*types.Organization{{ID: "firefly_5", ExposedConnectorPort: 7892}},
+				VersionManifest: &types.VersionManifest{Evmconnect: &getManifest.ManifestEntry},
+				EnvironmentVars: map[string]interface{}{"HTTP_PROXY": ""},
+			},
+			DependentServices: map[string]string{
+				"service1": "running",
+				"service2": "stopped",
+			},
+			ServiceName: "evmconnect_firefly_5",
+		},
 	}
 	for _, tc := range testServices {
 		t.Run(tc.Name, func(t *testing.T) {
@@ -90,7 +103,12 @@ func TestGetServiceDefinition(t *testing.T) {
 			if serviceDefinitions[0].ServiceName != tc.ServiceName {
 				t.Errorf("Expected ServiceName %q, got %q", tc.ServiceName, serviceDefinitions[0].ServiceName)
 			}
-
+			if len(tc.Members.EnvironmentVars) != len(serviceDefinitions[0].Service.Environment) {
+				t.Errorf("Expected EnvironmentVars %q, got %q", tc.Members.EnvironmentVars, serviceDefinitions[0].Service.Environment)
+			}
+			for k := range tc.Members.EnvironmentVars {
+				assert.Equal(t, tc.Members.EnvironmentVars[k], serviceDefinitions[0].Service.Environment[k])
+			}
 		})
 	}
 

--- a/internal/blockchain/ethereum/ethsigner/ethsigner.go
+++ b/internal/blockchain/ethereum/ethsigner/ethsigner.go
@@ -160,7 +160,8 @@ func (p *EthSignerProvider) GetDockerServiceDefinition(rpcURL string) *docker.Se
 				Interval: "15s", // 6000 requests in a day
 				Retries:  60,
 			},
-			Ports: []string{fmt.Sprintf("%d:8545", p.stack.ExposedBlockchainPort)},
+			Ports:       []string{fmt.Sprintf("%d:8545", p.stack.ExposedBlockchainPort)},
+			Environment: p.stack.EnvironmentVars,
 		},
 		VolumeNames: []string{
 			"ethsigner",

--- a/internal/blockchain/ethereum/geth/geth_provider.go
+++ b/internal/blockchain/ethereum/geth/geth_provider.go
@@ -190,6 +190,7 @@ func (p *GethProvider) GetDockerServiceDefinitions() []*docker.ServiceDefinition
 			Volumes:       []string{"geth:/data"},
 			Logging:       docker.StandardLogOptions,
 			Ports:         []string{fmt.Sprintf("%d:8545", p.stack.ExposedBlockchainPort)},
+			Environment:   p.stack.EnvironmentVars,
 		},
 		VolumeNames: []string{"geth"},
 	}

--- a/internal/blockchain/fabric/fabric_docker.go
+++ b/internal/blockchain/fabric/fabric_docker.go
@@ -31,7 +31,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricCAImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_ca", s.Name),
-				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
+				Environment: s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 					"FABRIC_CA_HOME":                            "/etc/hyperledger/fabric-ca-server",
 					"FABRIC_CA_SERVER_CA_NAME":                  "fabric_ca",
 					"FABRIC_CA_SERVER_PORT":                     "7054",
@@ -57,7 +57,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricOrdererImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_orderer", s.Name),
-				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
+				Environment: s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 					"FABRIC_LOGGING_SPEC":                       "INFO",
 					"ORDERER_GENERAL_LISTENADDRESS":             "0.0.0.0",
 					"ORDERER_GENERAL_LISTENPORT":                "7050",
@@ -103,7 +103,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricPeerImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_peer", s.Name),
-				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
+				Environment: s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 					"CORE_VM_ENDPOINT":                      "unix:///host/var/run/docker.sock",
 					"CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE": fmt.Sprintf("%s_default", s.Name),
 					"FABRIC_LOGGING_SPEC":                   "INFO",

--- a/internal/blockchain/fabric/fabric_docker.go
+++ b/internal/blockchain/fabric/fabric_docker.go
@@ -31,14 +31,14 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricCAImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_ca", s.Name),
-				Environment: map[string]interface{}{
+				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
 					"FABRIC_CA_HOME":                            "/etc/hyperledger/fabric-ca-server",
 					"FABRIC_CA_SERVER_CA_NAME":                  "fabric_ca",
 					"FABRIC_CA_SERVER_PORT":                     "7054",
 					"FABRIC_CA_SERVER_OPERATIONS_LISTENADDRESS": "0.0.0.0:17054",
 					"FABRIC_CA_SERVER_CA_CERTFILE":              "/etc/firefly/organizations/peerOrganizations/org1.example.com/ca/fabric_ca.org1.example.com-cert.pem",
 					"FABRIC_CA_SERVER_CA_KEYFILE":               "/etc/firefly/organizations/peerOrganizations/org1.example.com/ca/priv_sk",
-				},
+				}),
 				Ports: []string{
 					"7054:7054",
 					"17054:17054",
@@ -57,7 +57,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricOrdererImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_orderer", s.Name),
-				Environment: map[string]interface{}{
+				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
 					"FABRIC_LOGGING_SPEC":                       "INFO",
 					"ORDERER_GENERAL_LISTENADDRESS":             "0.0.0.0",
 					"ORDERER_GENERAL_LISTENPORT":                "7050",
@@ -81,7 +81,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 					"ORDERER_ADMIN_TLS_CLIENTROOTCAS":           "[/etc/firefly/organizations/ordererOrganizations/example.com/orderers/fabric_orderer.example.com/tls/ca.crt]",
 					"ORDERER_ADMIN_LISTENADDRESS":               "0.0.0.0:7053",
 					"ORDERER_OPERATIONS_LISTENADDRESS":          "0.0.0.0:17050",
-				},
+				}),
 				WorkingDir: "/opt/gopath/src/github.com/hyperledger/fabric",
 				Command:    "orderer",
 				Volumes: []string{
@@ -103,7 +103,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 			Service: &docker.Service{
 				Image:         FabricPeerImageName,
 				ContainerName: fmt.Sprintf("%s_fabric_peer", s.Name),
-				Environment: map[string]interface{}{
+				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
 					"CORE_VM_ENDPOINT":                      "unix:///host/var/run/docker.sock",
 					"CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE": fmt.Sprintf("%s_default", s.Name),
 					"FABRIC_LOGGING_SPEC":                   "INFO",
@@ -122,7 +122,7 @@ func GenerateDockerServiceDefinitions(s *types.Stack) []*docker.ServiceDefinitio
 					"CORE_PEER_GOSSIP_EXTERNALENDPOINT":     "fabric_peer:7051",
 					"CORE_PEER_LOCALMSPID":                  "Org1MSP",
 					"CORE_OPERATIONS_LISTENADDRESS":         "0.0.0.0:17051",
-				},
+				}),
 				Volumes: []string{
 					"firefly_fabric:/etc/firefly",
 					"fabric_peer:/var/hyperledger/production",

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -290,7 +290,8 @@ func (p *FabricProvider) getFabconnectServiceDefinitions(members []*types.Organi
 				HealthCheck: &docker.HealthCheck{
 					Test: []string{"CMD", "wget", "-O", "-", "http://localhost:3000/status"},
 				},
-				Logging: docker.StandardLogOptions,
+				Logging:     docker.StandardLogOptions,
+				Environment: p.stack.EnvironmentVars,
 			},
 			VolumeNames: []string{
 				"fabconnect_receipts_" + member.ID,

--- a/internal/blockchain/tezos/connector/tezosconnect/docker.go
+++ b/internal/blockchain/tezos/connector/tezosconnect/docker.go
@@ -42,7 +42,8 @@ func (t *Tezosconnect) GetServiceDefinitions(s *types.Stack, dependentServices m
 					fmt.Sprintf("tezosconnect_config_%s:/tezosconnect/config", member.ID),
 					fmt.Sprintf("tezosconnect_leveldb_%s:/tezosconnect/leveldb", member.ID),
 				},
-				Logging: docker.StandardLogOptions,
+				Logging:     docker.StandardLogOptions,
+				Environment: s.EnvironmentVars,
 			},
 			VolumeNames: []string{
 				fmt.Sprintf("tezosconnect_config_%s", member.ID),

--- a/internal/blockchain/tezos/tezossigner/tezossigner.go
+++ b/internal/blockchain/tezos/tezossigner/tezossigner.go
@@ -113,6 +113,7 @@ func (p *TezosSignerProvider) GetDockerServiceDefinition(rpcURL string) *docker.
 				fmt.Sprintf("%d:6732", p.stack.ExposedBlockchainPort),
 				"9583:9583",
 			},
+			Environment: p.stack.EnvironmentVars,
 		},
 		VolumeNames: []string{
 			"tezossigner",

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -112,7 +112,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				Image:         constants.PostgresImageName,
 				ContainerName: fmt.Sprintf("%s_postgres_%s", s.Name, member.ID),
 				Ports:         []string{fmt.Sprintf("%d:5432", member.ExposedDatabasePort)},
-				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
+				Environment: s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 					"POSTGRES_PASSWORD": "f1refly",
 					"PGDATA":            "/var/lib/postgresql/data/pgdata"}),
 				Volumes: []string{fmt.Sprintf("postgres_%s:/var/lib/postgresql/data", member.ID)},
@@ -149,7 +149,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 			},
 		}
 		if s.IPFSMode.Equals(types.IPFSModePrivate) {
-			sharedStorage.Environment = s.ConcatenateEnvironmentVars(map[string]interface{}{
+			sharedStorage.Environment = s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 				"IPFS_SWARM_KEY":    s.SwarmKey,
 				"LIBP2P_FORCE_PNET": "1",
 			},
@@ -174,7 +174,7 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				Image:         constants.SandboxImageName,
 				ContainerName: fmt.Sprintf("%s_sandbox_%s", s.Name, member.ID),
 				Ports:         []string{fmt.Sprintf("%d:3001", member.ExposedSandboxPort)},
-				Environment: s.ConcatenateEnvironmentVars(map[string]interface{}{
+				Environment: s.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 					"FF_ENDPOINT": fmt.Sprintf("http://firefly_core_%d:%d", *member.Index, member.ExposedFireflyPort),
 				}),
 			}

--- a/internal/docker/docker_config_test.go
+++ b/internal/docker/docker_config_test.go
@@ -1,0 +1,54 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/hyperledger/firefly-cli/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockManfest struct {
+	types.ManifestEntry
+}
+
+func TestCreateDockerComposeEnvironmentVars(t *testing.T) {
+	getManifest := &MockManfest{}
+	testStacks := []struct {
+		Id              int
+		EnvironmentVars map[string]interface{}
+		Members         []*types.Organization
+		VersionManifest *types.VersionManifest
+	}{
+		{
+			Id:              1,
+			Members:         []*types.Organization{{ID: "firefly_1"}},
+			VersionManifest: &types.VersionManifest{FireFly: &getManifest.ManifestEntry, DataExchange: &getManifest.ManifestEntry},
+			EnvironmentVars: map[string]interface{}{
+				"http_proxy":  "",
+				"https_proxy": "",
+				"HTTP_PROXY":  "127.0.0.1:8080",
+				"HTTPS_PROXY": "127.0.0.1:8080",
+				"no_proxy":    "",
+			},
+		},
+		{
+			Id:              2,
+			Members:         []*types.Organization{{ID: "firefly_2"}},
+			VersionManifest: &types.VersionManifest{FireFly: &getManifest.ManifestEntry, DataExchange: &getManifest.ManifestEntry},
+			EnvironmentVars: nil,
+		},
+	}
+	for _, test := range testStacks {
+		cfg := CreateDockerCompose(&types.Stack{
+			Members:         test.Members,
+			VersionManifest: test.VersionManifest,
+			EnvironmentVars: test.EnvironmentVars,
+		})
+		for _, service := range cfg.Services {
+			assert.Equal(t, len(test.EnvironmentVars), len(service.Environment), "service [%v] test ID [%v]", service.ContainerName, test.Id)
+			for envVar := range service.Environment {
+				assert.Equal(t, test.EnvironmentVars[envVar], service.Environment[envVar])
+			}
+		}
+	}
+}

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -88,6 +88,10 @@ func NewStackManager(ctx context.Context) *StackManager {
 }
 
 func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
+	environmentVarsMap := make(map[string]interface{})
+	for key, value := range options.EnvironmentVars {
+		environmentVarsMap[key] = value
+	}
 	s.Stack = &types.Stack{
 		Name:                   options.StackName,
 		Members:                make([]*types.Organization, options.MemberCount),
@@ -114,6 +118,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		ChaincodeName:     options.ChaincodeName,
 		CustomPinSupport:  options.CustomPinSupport,
 		RemoteNodeDeploy:  options.RemoteNodeDeploy,
+		EnvironmentVars:   environmentVarsMap,
 	}
 
 	tokenProviders, err := types.FFEnumArray(s.ctx, options.TokenProviders)

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -96,7 +96,7 @@ func (p *ERC1155Provider) GetDockerServiceDefinitions(tokenIdx int) []*docker.Se
 			}
 		}
 
-		env := p.stack.ConcatenateEnvironmentVars(map[string]interface{}{
+		env := p.stack.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 			"ETHCONNECT_URL":   p.blockchainProvider.GetConnectorURL(member),
 			"ETHCONNECT_TOPIC": connectorName,
 			"AUTO_INIT":        "false",

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -96,12 +96,12 @@ func (p *ERC1155Provider) GetDockerServiceDefinitions(tokenIdx int) []*docker.Se
 			}
 		}
 
-		env := map[string]interface{}{
+		env := p.stack.ConcatenateEnvironmentVars(map[string]interface{}{
 			"ETHCONNECT_URL":   p.blockchainProvider.GetConnectorURL(member),
 			"ETHCONNECT_TOPIC": connectorName,
 			"AUTO_INIT":        "false",
 			"CONTRACT_ADDRESS": contractAddress,
-		}
+		})
 		serviceDefinitions = append(serviceDefinitions, &docker.ServiceDefinition{
 			ServiceName: connectorName,
 			Service: &docker.Service{

--- a/internal/tokens/erc20erc721/erc20_erc721_provider.go
+++ b/internal/tokens/erc20erc721/erc20_erc721_provider.go
@@ -96,7 +96,7 @@ func (p *ERC20ERC721Provider) GetDockerServiceDefinitions(tokenIdx int) []*docke
 			}
 		}
 
-		env := p.stack.ConcatenateEnvironmentVars(map[string]interface{}{
+		env := p.stack.ConcatenateWithProvidedEnvironmentVars(map[string]interface{}{
 			"ETHCONNECT_URL":   p.blockchainProvider.GetConnectorURL(member),
 			"ETHCONNECT_TOPIC": connectorName,
 			"AUTO_INIT":        "false",

--- a/internal/tokens/erc20erc721/erc20_erc721_provider.go
+++ b/internal/tokens/erc20erc721/erc20_erc721_provider.go
@@ -96,11 +96,11 @@ func (p *ERC20ERC721Provider) GetDockerServiceDefinitions(tokenIdx int) []*docke
 			}
 		}
 
-		env := map[string]interface{}{
+		env := p.stack.ConcatenateEnvironmentVars(map[string]interface{}{
 			"ETHCONNECT_URL":   p.blockchainProvider.GetConnectorURL(member),
 			"ETHCONNECT_TOPIC": connectorName,
 			"AUTO_INIT":        "false",
-		}
+		})
 
 		if !p.stack.DisableTokenFactories && factoryAddress != "" {
 			env["FACTORY_CONTRACT_ADDRESS"] = factoryAddress

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -65,6 +65,7 @@ type InitOptions struct {
 	ChaincodeName            string
 	CustomPinSupport         bool
 	RemoteNodeDeploy         bool
+	EnvironmentVars          map[string]string
 }
 
 const IPFSMode = "ipfs_mode"

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -25,35 +25,36 @@ import (
 )
 
 type Stack struct {
-	Name                   string           `json:"name,omitempty"`
-	Members                []*Organization  `json:"members,omitempty"`
-	SwarmKey               string           `json:"swarmKey,omitempty"`
-	ExposedBlockchainPort  int              `json:"exposedBlockchainPort,omitempty"`
-	Database               fftypes.FFEnum   `json:"database"`
-	BlockchainProvider     fftypes.FFEnum   `json:"blockchainProvider"`
-	BlockchainConnector    fftypes.FFEnum   `json:"blockchainConnector"`
-	BlockchainNodeProvider fftypes.FFEnum   `json:"blockchainNodeProvider"`
-	TokenProviders         []fftypes.FFEnum `json:"tokenProviders"`
-	VersionManifest        *VersionManifest `json:"versionManifest,omitempty"`
-	PrometheusEnabled      bool             `json:"prometheusEnabled,omitempty"`
-	SandboxEnabled         bool             `json:"sandboxEnabled,omitempty"`
-	MultipartyEnabled      bool             `json:"multiparty"`
-	ExposedPrometheusPort  int              `json:"exposedPrometheusPort,omitempty"`
-	ContractAddress        string           `json:"contractAddress,omitempty"`
-	ChainIDPtr             *int64           `json:"chainID,omitempty"`
-	RemoteNodeURL          string           `json:"remoteNodeURL,omitempty"`
-	DisableTokenFactories  bool             `json:"disableTokenFactories,omitempty"`
-	RequestTimeout         int              `json:"requestTimeout,omitempty"`
-	IPFSMode               fftypes.FFEnum   `json:"ipfsMode"`
-	RemoteFabricNetwork    bool             `json:"remoteFabricNetwork,omitempty"`
-	ChannelName            string           `json:"channelName,omitempty"`
-	ChaincodeName          string           `json:"chaincodeName,omitempty"`
-	CustomPinSupport       bool             `json:"customPinSupport,omitempty"`
-	RemoteNodeDeploy       bool             `json:"remoteNodeDeploy,omitempty"`
-	InitDir                string           `json:"-"`
-	RuntimeDir             string           `json:"-"`
-	StackDir               string           `json:"-"`
-	State                  *StackState      `json:"-"`
+	Name                   string                 `json:"name,omitempty"`
+	Members                []*Organization        `json:"members,omitempty"`
+	SwarmKey               string                 `json:"swarmKey,omitempty"`
+	ExposedBlockchainPort  int                    `json:"exposedBlockchainPort,omitempty"`
+	Database               fftypes.FFEnum         `json:"database"`
+	BlockchainProvider     fftypes.FFEnum         `json:"blockchainProvider"`
+	BlockchainConnector    fftypes.FFEnum         `json:"blockchainConnector"`
+	BlockchainNodeProvider fftypes.FFEnum         `json:"blockchainNodeProvider"`
+	TokenProviders         []fftypes.FFEnum       `json:"tokenProviders"`
+	VersionManifest        *VersionManifest       `json:"versionManifest,omitempty"`
+	PrometheusEnabled      bool                   `json:"prometheusEnabled,omitempty"`
+	SandboxEnabled         bool                   `json:"sandboxEnabled,omitempty"`
+	MultipartyEnabled      bool                   `json:"multiparty"`
+	ExposedPrometheusPort  int                    `json:"exposedPrometheusPort,omitempty"`
+	ContractAddress        string                 `json:"contractAddress,omitempty"`
+	ChainIDPtr             *int64                 `json:"chainID,omitempty"`
+	RemoteNodeURL          string                 `json:"remoteNodeURL,omitempty"`
+	DisableTokenFactories  bool                   `json:"disableTokenFactories,omitempty"`
+	RequestTimeout         int                    `json:"requestTimeout,omitempty"`
+	IPFSMode               fftypes.FFEnum         `json:"ipfsMode"`
+	RemoteFabricNetwork    bool                   `json:"remoteFabricNetwork,omitempty"`
+	ChannelName            string                 `json:"channelName,omitempty"`
+	ChaincodeName          string                 `json:"chaincodeName,omitempty"`
+	CustomPinSupport       bool                   `json:"customPinSupport,omitempty"`
+	RemoteNodeDeploy       bool                   `json:"remoteNodeDeploy,omitempty"`
+	EnvironmentVars        map[string]interface{} `json:"environmentVars"`
+	InitDir                string                 `json:"-"`
+	RuntimeDir             string                 `json:"-"`
+	StackDir               string                 `json:"-"`
+	State                  *StackState            `json:"-"`
 }
 
 func (s *Stack) ChainID() int64 {
@@ -105,4 +106,15 @@ func (s *Stack) IsOldFileStructure() (bool, error) {
 	default:
 		return false, nil
 	}
+}
+
+func (s *Stack) ConcatenateEnvironmentVars(input map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range input {
+		result[k] = v
+	}
+	for k, v := range s.EnvironmentVars {
+		result[k] = v // Overwrites existing keys from previous map
+	}
+	return result
 }

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -108,7 +108,7 @@ func (s *Stack) IsOldFileStructure() (bool, error) {
 	}
 }
 
-func (s *Stack) ConcatenateEnvironmentVars(input map[string]interface{}) map[string]interface{} {
+func (s *Stack) ConcatenateWithProvidedEnvironmentVars(input map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 	for k, v := range input {
 		result[k] = v


### PR DESCRIPTION
This PR adds a `--environment-vars` flag to the **init** command to allow docker compose generation to include generic environment variables across all containers. When docker is started against a corporate proxy, containers are unable to resolve via the internal DNS names due to the proxy. 

In this instance, users need to unset the proxy by passing in environment variables `HTTP_PROXY=,http_proxy=` to the containers. Depending on needs, other proxy specific environment variables can be set as well.

Resolves #302 