### PR TITLE
fix tessera for ARM64

### DIFF
--- a/internal/blockchain/ethereum/quorum/quorum_provider.go
+++ b/internal/blockchain/ethereum/quorum/quorum_provider.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -257,9 +258,14 @@ func (p *QuorumProvider) GetDockerServiceDefinitions() []*docker.ServiceDefiniti
 					Ports:         []string{fmt.Sprintf("%d:%s", p.stack.ExposedPtmPort+(i*ExposedBlockchainPortMultiplier), TmTpPort)}, // defaults 4100, 4110, 4120, 4130
 					Environment:   p.stack.EnvironmentVars,
 					EntryPoint:    []string{"/bin/sh", "-c", "/data/docker-entrypoint.sh"},
-					Deploy:        map[string]interface{}{"restart_policy": map[string]string{"condition": "on-failure", "max_attempts": "3"}},
+					Deploy:        map[string]interface{}{"restart_policy": map[string]interface{}{"condition": "on-failure", "max_attempts": int64(3)}},
 				},
 				VolumeNames: []string{fmt.Sprintf("tessera_%d", i)},
+			}
+
+			// No arm64 images for Tessera
+			if runtime.GOARCH == "arm64" {
+				serviceDefinitions[i+memberCount].Service.Platform = "linux/amd64"
 			}
 		}
 		serviceDefinitions[i] = &docker.ServiceDefinition{

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -61,6 +61,7 @@ type Service struct {
 	EnvFile       string                       `yaml:"env_file,omitempty"`
 	Expose        []int                        `yaml:"expose,omitempty"`
 	Deploy        map[string]interface{}       `yaml:"deploy,omitempty"`
+	Platform      string                       `yaml:"platform,omitempty"`
 }
 
 type DockerComposeConfig struct {
@@ -79,7 +80,7 @@ var StandardLogOptions = &LoggingConfig{
 
 func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 	compose := &DockerComposeConfig{
-		Version:  "2.1",
+		Version:  "2.4",
 		Services: make(map[string]*Service),
 		Volumes:  make(map[string]struct{}),
 	}


### PR DESCRIPTION
There are no official images for Tessera that can run in ARM64 so we need to use the `--platform` flag to emulate them using the `AMD64` images

In draft as hitting 

```
Error: unable to unlock account 0xfd8670b57e184bdd76d1f2c1fcac44c444399615 - all changes rolled back
```