### PR TITLE
Add healthcheck for firefly and extra log info for image

### DIFF
--- a/internal/core/manifest.go
+++ b/internal/core/manifest.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/hyperledger/firefly-cli/internal/constants"
 	"github.com/hyperledger/firefly-cli/internal/docker"
+	"github.com/hyperledger/firefly-cli/internal/log"
 	"github.com/hyperledger/firefly-cli/pkg/types"
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 )
@@ -107,7 +109,7 @@ func getSHA(imageName, imageTag string) (string, error) {
 	}
 }
 
-func ReadManifestFile(p string) (*types.VersionManifest, error) {
+func ReadManifestFile(ctx context.Context, p string) (*types.VersionManifest, error) {
 	d, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
@@ -117,6 +119,8 @@ func ReadManifestFile(p string) (*types.VersionManifest, error) {
 
 	// If core is not specified in the manifest, use a locally built image called "firefly"
 	if manifest.FireFly == nil {
+		log := log.LoggerFromContext(ctx)
+		log.Warn("No FireFly image present in manifest provided, using local image hypeledger/firefly")
 		manifest.FireFly = &types.ManifestEntry{
 			Image: "hyperledger/firefly",
 			Local: true,

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -104,6 +104,16 @@ func CreateDockerCompose(s *types.Stack) *DockerComposeConfig {
 				DependsOn:   map[string]map[string]string{},
 				Logging:     StandardLogOptions,
 				Environment: s.EnvironmentVars,
+				HealthCheck: &HealthCheck{
+					Test: []string{
+						"CMD",
+						"curl",
+						"--fail",
+						fmt.Sprintf("http://localhost:%d/api/v1/status", member.ExposedFireflyPort),
+					},
+					Interval: "15s", // 6000 requests in a day
+					Retries:  30,
+				},
 			}
 			compose.Volumes[fmt.Sprintf("%s_data_%s", fireflyCore, member.ID)] = struct{}{}
 			compose.Services[fireflyCore+"_"+member.ID].DependsOn["dataexchange_"+member.ID] = map[string]string{"condition": "service_started"}

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -160,7 +160,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 
 	if options.ManifestPath != "" {
 		// If a path to a manifest file is set, read the existing file
-		manifest, err = core.ReadManifestFile(options.ManifestPath)
+		manifest, err = core.ReadManifestFile(s.ctx, options.ManifestPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Improve the health check of FireFly and logging if the manifest provided doesn't have a FF image