### PR TITLE
Cleanup code masking useful error message

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -55,8 +55,8 @@ var initCmd = &cobra.Command{
 			return err
 		}
 		if err := stackManager.InitStack(&initOptions); err != nil {
-			if err := stackManager.RemoveStack(); err != nil {
-				return err
+			if cleanupErr := stackManager.RemoveStack(); cleanupErr != nil {
+				fmt.Printf("Cleanup from previous error returned: %s", cleanupErr)
 			}
 			return err
 		}


### PR DESCRIPTION
After fix in this PR - quickly shows the simple environmental problem with my local setup:
```
initializing new FireFly stack...
Cleanup from previous error returned: stat /Users/pbroadhurst/.firefly/stacks/dev/docker-compose.yml: no such file or directory
Error: reading image "ghcr.io/hyperledger/firefly:latest": GET https://ghcr.io/token?scope=repository%3Ahyperledger%2Ffirefly%3Apull&service=ghcr.io: DENIED ....
```

Before fix in this PR - extremely confusing, as it doesn't mention the actual error:

```
ff init dev --block-period 1 -n quorum --private-transaction-manager tessera -c ethconnect 1 
initializing new FireFly stack...
Error: stat /Users/pbroadhurst/.firefly/stacks/dev/docker-compose.yml: no such file or directory
```
