### PR TITLE
Add --nodiscover to Quorum command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 .idea/
 docs/command_docs
 coverage.txt
+.vscode
+!.vscode/launch.json
+!.vscode/settings.json

--- a/internal/blockchain/ethereum/ethsigner/config.go
+++ b/internal/blockchain/ethereum/ethsigner/config.go
@@ -19,7 +19,7 @@ package ethsigner
 import (
 	"os"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type FileWalletFilenamesConfig struct {

--- a/internal/blockchain/ethereum/tessera/tessera.go
+++ b/internal/blockchain/ethereum/tessera/tessera.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package quorum
+package tessera
 
 import (
 	"context"
@@ -32,7 +32,6 @@ var DockerEntrypoint = "docker-entrypoint.sh"
 var TmQ2tPort = "9101"
 var TmTpPort = "9080"
 var TmP2pPort = "9000"
-var QuorumPort = "8545"
 
 type PrivateKeyData struct {
 	Bytes string `json:"bytes"`

--- a/internal/blockchain/ethereum/tessera/tessera_test.go
+++ b/internal/blockchain/ethereum/tessera/tessera_test.go
@@ -1,4 +1,4 @@
-package quorum
+package tessera
 
 import (
 	"context"


### PR DESCRIPTION
I noticed after starting a Quroum developer environment with the CLI it was attempting to peer with the public list of ethereum nodes.
This PR adds the `--nodiscover` command line option to stop this.

Couple of other minor changes proposes:
- Moving `tessera` to its own directory
    - code naming coupling directly to Quorum seemed a little confusing - as it does as a component work with HL Besu as well (even though that hasn't yet been contributed
- Changing the code checks to `Equals(types.PrivateTransactionManagerTessera)` for code blocks that are Tessera specific
    - concept of `--private-transaction-manager` isn't exclusive to Tessera, and this will avoid catching out future contributions that provide other options