### PR TITLE
chore: Get executable name from the command

### DIFF
--- a/cmd/accounts_create.go
+++ b/cmd/accounts_create.go
@@ -50,7 +50,7 @@ var accountsCreateCmd = &cobra.Command{
 		}
 		account, err := stackManager.CreateAccount(args[1:])
 		if err != nil {
-			return err
+			return fmt.Errorf("%s. usage: %s accounts create <stack_name> <org_name> <account_name>", err.Error(), ExecutableName)
 		}
 		fmt.Print(account)
 		fmt.Print("\n")

--- a/cmd/accounts_list_test.go
+++ b/cmd/accounts_list_test.go
@@ -11,7 +11,7 @@ func TestAccountListCmd(t *testing.T) {
 	testNames := []string{"stack-1", "stack-2", "stack-3", "stack-4", "stack-5"}
 	for _, stackNames := range testNames {
 		createCmd := accountsCreateCmd
-		createCmd.SetArgs([]string{"ff", "create", stackNames})
+		createCmd.SetArgs([]string{ExecutableName, "create", stackNames})
 		err := createCmd.Execute()
 		if err != nil {
 			t.Fatalf("Failed to create account for testing: %v", err)

--- a/cmd/deploy_ethereum.go
+++ b/cmd/deploy_ethereum.go
@@ -72,7 +72,7 @@ solc --combined-json abi,bin contract.sol > contract.json
 		}
 		location, err := stackManager.DeployContract(filename, selectedContractName, 0, args[2:])
 		if err != nil {
-			return err
+			return fmt.Errorf("%s. usage: %s deploy <stack_name> <filename> <channel> <chaincode> <version>", err.Error(), ExecutableName)
 		}
 		fmt.Print(location)
 		return nil

--- a/cmd/deploy_fabric.go
+++ b/cmd/deploy_fabric.go
@@ -51,7 +51,7 @@ var deployFabricCmd = &cobra.Command{
 		}
 		contractAddress, err := stackManager.DeployContract(filename, filename, 0, args[2:])
 		if err != nil {
-			return err
+			return fmt.Errorf("%s. usage: %s deploy <stack_name> <filename> <channel> <chaincode> <version>", err.Error(), ExecutableName)
 		}
 		fmt.Print(contractAddress)
 		return nil

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -50,7 +50,7 @@ var psCmd = &cobra.Command{
 				if contains(allStacks, strings.TrimSpace(stackName)) {
 					namedStacks = append(namedStacks, stackName)
 				} else {
-					fmt.Printf("stack name - %s, is not present on your local machine. Run `ff ls` to see all available stacks.\n", stackName)
+					fmt.Printf("stack name - %s, is not present on your local machine. Run `%s ls` to see all available stacks.\n", stackName, ExecutableName)
 				}
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,9 @@ var logger log.Logger = &log.StdoutLogger{
 	LogLevel: log.Debug,
 }
 
+// name of the executable, this is for the help messages
+var ExecutableName string = os.Args[0]
+
 func GetFireflyASCIIArt() string {
 	s := ""
 	s += "\u001b[33m    _______           ________     \u001b[0m\n"   // yellow
@@ -53,7 +56,7 @@ func GetFireflyASCIIArt() string {
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "ff",
+	Use:   ExecutableName,
 	Short: "FireFly CLI is a developer tool used to manage local development stacks",
 	Long: GetFireflyASCIIArt() + `
 FireFly CLI is a developer tool used to manage local development stacks
@@ -62,7 +65,7 @@ This tool automates creation of stacks with many infrastructure components which
 would otherwise be a time consuming manual task. It also wraps docker compose
 commands to manage the lifecycle of stacks.
 
-To get started run: ff init
+To get started run: ` + ExecutableName + ` init
 Optional: Set FIREFLY_HOME env variable for FireFly stack configuration path.
 	`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,9 +28,12 @@ import (
 var shortened = false
 var output = "json"
 
-var BuildDate string            // set by go-releaser
-var BuildCommit string          // set by go-releaser
-var BuildVersionOverride string // set by go-releaser
+// set by go-releaser
+var (
+	BuildDate            string
+	BuildCommit          string
+	BuildVersionOverride string
+)
 
 // Info creates a formattable struct for version output
 type Info struct {

--- a/internal/blockchain/fabric/fabric_provider.go
+++ b/internal/blockchain/fabric/fabric_provider.go
@@ -522,11 +522,11 @@ func (p *FabricProvider) DeployContract(filename, contractName, instanceName str
 	}
 	switch {
 	case len(extraArgs) < 1:
-		return nil, fmt.Errorf("channel not set. usage: ff deploy <stack_name> <filename> <channel> <chaincode> <version>")
+		return nil, fmt.Errorf("channel not set")
 	case len(extraArgs) < 2:
-		return nil, fmt.Errorf("chaincode not set. usage: ff deploy <stack_name> <filename> <channel> <chaincode> <version>")
+		return nil, fmt.Errorf("chaincode not set")
 	case len(extraArgs) < 3:
-		return nil, fmt.Errorf("version not set. usage: ff deploy <stack_name> <filename> <channel> <chaincode> <version>")
+		return nil, fmt.Errorf("version not set")
 	}
 	channel := extraArgs[0]
 	chaincode := extraArgs[1]
@@ -587,9 +587,9 @@ func (p *FabricProvider) CreateAccount(args []string) (interface{}, error) {
 	}
 	switch {
 	case len(args) < 1:
-		return "", fmt.Errorf("org name not set. usage: ff accounts create <stack_name> <org_name> <account_name>")
+		return "", fmt.Errorf("org name not set")
 	case len(args) < 2:
-		return "", fmt.Errorf("account name not set. usage: ff accounts create <stack_name> <org_name> <account_name>")
+		return "", fmt.Errorf("account name not set")
 	}
 	orgName := args[0]
 	accountName := args[1]


### PR DESCRIPTION
This PR enhances the FireFly CLI by making the executable name dynamic in the help messages. Instead of hardcoding the executable name, it is now loaded from the command-line arguments, allowing for dynamic help messages that reflect the actual executable name being used.

Before:
```
% firefly

To get started run: ff init
Optional: Set FIREFLY_HOME env variable for FireFly stack configuration path.

Usage:
  ff [command]
```

After:
```
% firefly

To get started run: firefly init
Optional: Set FIREFLY_HOME env variable for FireFly stack configuration path.

Usage:
  firefly [command]
```