### PR TITLE
fix broken pipe code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 permissions:
+  contents: read
   contents: write
 
 jobs:
@@ -20,6 +21,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.22.6"
       - name: Compile FireFly CLI
         run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 permissions:
-  contents: read
   contents: write
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22.6"
+          go-version: "1.23"
       - name: Compile FireFly CLI
         run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.22"
       - name: Compile FireFly CLI
         run: make

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: format build lint test tidy
 format: ## Formats all go code
 		gofmt -s -w .
 test: deps
-		$(VGO) test ./internal/... ./pkg/... ./cmd/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=60s ${TEST_ARGS}
+		$(VGO) test ./internal/... ./pkg/... ./cmd/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s ${TEST_ARGS}
 build: ## Builds all go code
 		cd ff && go build -ldflags="-X 'github.com/hyperledger/firefly-cli/cmd.BuildDate=$(DATE)' -X 'github.com/hyperledger/firefly-cli/cmd.BuildCommit=$(GITREF)'"
 install: ## Installs the package

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: format build lint test tidy
 format: ## Formats all go code
 		gofmt -s -w .
 test: deps
-		$(VGO) test ./internal/... ./pkg/... ./cmd/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=30s ${TEST_ARGS}
+		$(VGO) test ./internal/... ./pkg/... ./cmd/... -cover -coverprofile=coverage.txt -covermode=atomic -timeout=60s ${TEST_ARGS}
 build: ## Builds all go code
 		cd ff && go build -ldflags="-X 'github.com/hyperledger/firefly-cli/cmd.BuildDate=$(DATE)' -X 'github.com/hyperledger/firefly-cli/cmd.BuildCommit=$(GITREF)'"
 install: ## Installs the package

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@
 
 module github.com/hyperledger/firefly-cli
 
-go 1.23
+go 1.22
 
-toolchain go1.23
+toolchain go1.22.6
 
 require (
 	blockwatch.cc/tzgo v1.17.4

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@
 
 module github.com/hyperledger/firefly-cli
 
-go 1.22
+go 1.22.6
 
-toolchain go1.22.0
+toolchain go1.22.6
 
 require (
 	blockwatch.cc/tzgo v1.17.4

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,9 @@
 
 module github.com/hyperledger/firefly-cli
 
-go 1.22.6
+go 1.23
+
+toolchain go1.23
 
 require (
 	blockwatch.cc/tzgo v1.17.4

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,6 @@ module github.com/hyperledger/firefly-cli
 
 go 1.22.6
 
-toolchain go1.22.6
-
 require (
 	blockwatch.cc/tzgo v1.17.4
 	github.com/briandowns/spinner v1.23.0


### PR DESCRIPTION
Don't ask me how but Go 1.22.6 fixes the coverage broken pipe problem


See problem at https://github.com/hyperledger/firefly-cli/actions/runs/10832284030/job/30956922782#step:4:1