### PR TITLE
Relax year check on copyright header in golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters-settings:
     values:
       regexp:
         COMPANY: .*
+        YEAR: '\d\d\d\d(-\d\d\d\d)?'
     template: |-
       Copyright © {{ YEAR }} {{ COMPANY }}
 

--- a/cmd/init_fabric.go
+++ b/cmd/init_fabric.go
@@ -1,4 +1,3 @@
-///
 // Copyright © 2024 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Inspired by https://github.com/hyperledger/firefly/pull/1649/files

Fixes: https://github.com/hyperledger/firefly-cli/actions/runs/12630600319/job/35190729382 that complains about a year change when the file hasn't been changed 