### PR TITLE
Sort Git tag by date in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,3 +47,6 @@ changelog:
       - "^test:"
 release:
   prerelease: auto
+git:
+  # Sort Git tags by date, the default behaviour lists release candidates first regardless of date
+  tag_sort: -version:creatordate


### PR DESCRIPTION
Failure in v1.3.3 release https://github.com/hyperledger/firefly-cli/actions/runs/14037243248/job/39298579545 is caused by the `GoReleaser` tool thinking the release candidate `v1.3.3-rc.1` is the newest one because of the way it sorts..

Found https://github.com/goreleaser/goreleaser/pull/3611/files#diff-387a86836bbc80da7865b5ccf079e7b6d7c82a673d5c6538892e24e1bdf17d14R9-R14 