### PR TITLE
Add --blockfrost-base-url for cardano

### DIFF
--- a/cmd/init_cardano.go
+++ b/cmd/init_cardano.go
@@ -64,6 +64,7 @@ func init() {
 	initCardanoCmd.Flags().StringVar(&initOptions.Network, "network", "mainnet", "The name of the network to connect to")
 	initCardanoCmd.Flags().StringVar(&initOptions.Socket, "socket", "", "Socket to mount for the cardano node to connect to")
 	initCardanoCmd.Flags().StringVar(&initOptions.BlockfrostKey, "blockfrost-key", "", "Blockfrost key")
+	initCardanoCmd.Flags().StringVar(&initOptions.BlockfrostBaseURL, "blockfrost-base-url", "", "Blockfrost base URL (for run-your-own blockfrost setups)")
 
 	initCmd.AddCommand(initCardanoCmd)
 }

--- a/internal/blockchain/cardano/connector/cardanoconnect/config.go
+++ b/internal/blockchain/cardano/connector/cardanoconnect/config.go
@@ -50,9 +50,10 @@ type ConnectorConfig struct {
 }
 
 type BlockchainConfig struct {
-	BlockfrostKey string `yaml:"blockfrostKey,omitempty"`
-	Socket        string `yaml:"socket,omitempty"`
-	Network       string `yaml:"network,omitempty"`
+	BlockfrostKey     string `yaml:"blockfrostKey,omitempty"`
+	BlockfrostBaseURL string `yaml:"blockfrostBaseUrl,omitempty"`
+	Socket            string `yaml:"socket,omitempty"`
+	Network           string `yaml:"network,omitempty"`
 }
 
 type ContractsConfig struct {
@@ -137,9 +138,10 @@ func (c *Cardanoconnect) GenerateConfig(stack *types.Stack, org *types.Organizat
 		},
 		Connector: &ConnectorConfig{
 			Blockchain: &BlockchainConfig{
-				BlockfrostKey: stack.BlockfrostKey,
-				Network:       stack.Network,
-				Socket:        socket,
+				BlockfrostKey:     stack.BlockfrostKey,
+				BlockfrostBaseURL: stack.BlockfrostBaseURL,
+				Network:           stack.Network,
+				Socket:            socket,
 			},
 			Contracts: &ContractsConfig{
 				ComponentsPath: "/cardanoconnect/contracts/components",

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -124,6 +124,7 @@ func (s *StackManager) InitStack(options *types.InitOptions) (err error) {
 		ChainIDPtr:        &options.ChainID,
 		Network:           options.Network,
 		BlockfrostKey:     options.BlockfrostKey,
+		BlockfrostBaseURL: options.BlockfrostBaseURL,
 		Socket:            options.Socket,
 		RemoteNodeURL:     options.RemoteNodeURL,
 		RequestTimeout:    options.RequestTimeout,

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -60,6 +60,7 @@ type InitOptions struct {
 	Network                   string
 	Socket                    string
 	BlockfrostKey             string
+	BlockfrostBaseURL         string
 	DisableTokenFactories     bool
 	RequestTimeout            int
 	ReleaseChannel            string

--- a/pkg/types/stack.go
+++ b/pkg/types/stack.go
@@ -47,6 +47,7 @@ type Stack struct {
 	Network                   string                 `json:"network,omitempty"`
 	Socket                    string                 `json:"socket,omitempty"`
 	BlockfrostKey             string                 `json:"blockfrostKey,omitempty"`
+	BlockfrostBaseURL         string                 `json:"blockfrostBaseURL,omitempty"`
 	RemoteNodeURL             string                 `json:"remoteNodeURL,omitempty"`
 	DisableTokenFactories     bool                   `json:"disableTokenFactories,omitempty"`
 	RequestTimeout            int                    `json:"requestTimeout,omitempty"`


### PR DESCRIPTION
Just what it sounds like on the tin. Adds a `--blockfrost-base-url` option to the `init cardano` command.

NB: the current latest version of firefly-cradanoconnect ignores this setting, but an imminent release will respect it.