### PR TITLE
fix: IPFS peering never persists, and bitswap hangs even when peered

### DIFF
--- a/internal/stacks/ipfs_config.go
+++ b/internal/stacks/ipfs_config.go
@@ -34,6 +34,14 @@ func GenerateSwarmKey() (string, error) {
 // disables Kubo's AutoConf/public-network defaults, which are incompatible
 // with a private swarm (swarm.key / LIBP2P_FORCE_PNET) and otherwise prevent
 // the daemon from starting or from ever peering with other members.
+//
+// Routing.Type is set to "none" rather than "dht": a small private swarm hits
+// a long-standing upstream bug (https://github.com/ipfs/kubo/issues/8346)
+// where bitswap finds a provider via the DHT but never sends it a WANT
+// message if the swarm connection to that peer already existed, so content
+// fetches hang even though the peers are connected. With routing disabled,
+// bitswap has no choice but to broadcast wants directly to its connected
+// peers, which is all a 2+ node private swarm actually needs.
 func GenerateIPFSPrivateNetInitScript() string {
 	return `#!/bin/sh
 ipfs config --json AutoConf.Enabled false
@@ -41,7 +49,7 @@ ipfs config --json Bootstrap '[]'
 ipfs config --json DNS.Resolvers '{}'
 ipfs config --json Routing.DelegatedRouters '[]'
 ipfs config --json Ipns.DelegatedPublishers '[]'
-ipfs config Routing.Type dht
+ipfs config Routing.Type none
 ipfs config --json AutoTLS.Enabled false
 ipfs config --json Swarm.Transports.Network.Websocket false
 `

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -614,24 +615,46 @@ func (s *StackManager) peerIPFSNodes() error {
 		peerIDs[member.ID] = idResp.ID
 	}
 
+	type peeringPeer struct {
+		ID    string   `json:"ID"`
+		Addrs []string `json:"Addrs"`
+	}
+
 	for _, member := range s.Stack.Members {
+		peers := []peeringPeer{}
+		for _, other := range s.Stack.Members {
+			if member.ID == other.ID {
+				continue
+			}
+			peers = append(peers, peeringPeer{
+				ID:    peerIDs[other.ID],
+				Addrs: []string{fmt.Sprintf("/dns4/ipfs_%s/tcp/4001", other.ID)},
+			})
+		}
+		peersJSON, err := json.Marshal(peers)
+		if err != nil {
+			return err
+		}
+
+		// swarm/peering/add only registers the peer with the *running*
+		// daemon's in-memory peering service and returns success even when
+		// the peer is unreachable - it does not persist to Peering.Peers in
+		// the on-disk config, so the pairing is lost on the next restart.
+		// Writing through /api/v0/config persists it for real, and Kubo
+		// picks up the change live (no restart needed).
+		configURL := fmt.Sprintf("http://127.0.0.1:%d/api/v0/config?arg=Peering.Peers&arg=%s&json=true", member.ExposedIPFSApiPort, url.QueryEscape(string(peersJSON)))
+		if err := core.RequestWithRetry(s.ctx, http.MethodPost, configURL, nil, nil); err != nil {
+			return fmt.Errorf("failed to persist IPFS peering config for member %s: %w", member.ID, err)
+		}
+
 		for _, other := range s.Stack.Members {
 			if member.ID == other.ID {
 				continue
 			}
 			addr := fmt.Sprintf("/dns4/ipfs_%s/tcp/4001/p2p/%s", other.ID, peerIDs[other.ID])
-
-			// swarm/peering/add only registers the peer with Kubo's background
-			// reconnect service - it returns success even when the peer is
-			// unreachable, so it does not confirm a connection was made.
-			peeringURL := fmt.Sprintf("http://127.0.0.1:%d/api/v0/swarm/peering/add?arg=%s", member.ExposedIPFSApiPort, addr)
-			if err := core.RequestWithRetry(s.ctx, http.MethodPost, peeringURL, nil, nil); err != nil {
-				return fmt.Errorf("failed to peer IPFS node %s with %s: %w", member.ID, other.ID, err)
-			}
-
 			// swarm/connect dials synchronously and errors if the connection
 			// fails, so retrying it confirms the nodes are actually connected
-			// rather than just registered to reconnect in the background.
+			// now rather than waiting on the peering service's own timing.
 			connectURL := fmt.Sprintf("http://127.0.0.1:%d/api/v0/swarm/connect?arg=%s", member.ExposedIPFSApiPort, addr)
 			if err := core.RequestWithRetry(s.ctx, http.MethodPost, connectURL, nil, nil); err != nil {
 				return fmt.Errorf("failed to connect IPFS node %s to %s: %w", member.ID, other.ID, err)

--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -601,6 +601,8 @@ func (s *StackManager) peerIPFSNodes() error {
 		return nil
 	}
 
+	s.Log.Info("peering IPFS nodes")
+
 	type ipfsIDResponse struct {
 		ID string `json:"ID"`
 	}
@@ -659,8 +661,11 @@ func (s *StackManager) peerIPFSNodes() error {
 			if err := core.RequestWithRetry(s.ctx, http.MethodPost, connectURL, nil, nil); err != nil {
 				return fmt.Errorf("failed to connect IPFS node %s to %s: %w", member.ID, other.ID, err)
 			}
+			s.Log.Info(fmt.Sprintf("IPFS node %s peered with %s (%s)", member.ID, other.ID, peerIDs[other.ID]))
 		}
 	}
+
+	s.Log.Info("IPFS nodes peered successfully")
 	return nil
 }
 


### PR DESCRIPTION
## Background

#359 fixed the initial "IPFS nodes never peer" bug (private-network connection bug in `go-ipfs:v0.10.0`, mDNS unreliable on Linux Docker bridge networks in CI) by bumping to `ipfs/kubo:v0.42.0` and adding an explicit peering step (`swarm/peering/add` + `swarm/connect`) after startup.

It's still failing intermittently in CI and in the `firefly` Core E2E suite (see hyperledger-firefly/firefly#1766 run failures on `v1.5.0-rc.3`) with the same symptom: `Waiting for 2 orgs to appear` timing out after 10 minutes, IPFS shared storage downloads failing with `context deadline exceeded`.

## Root causes (two separate bugs)

**1. `swarm/peering/add` returns success but never persists anything.**

Verified directly: called the endpoint, got `{"Status":"success"}`, then immediately checked `ipfs config Peering.Peers` on the same node - it was `null`. The endpoint only registers the peer with the *running* daemon's in-memory peering service for that process's lifetime. It does not write to the on-disk config the way `ipfs config` (the CLI command) does.

This matters because `runFirstTimeSetup` does a full `docker compose stop` + restart partway through, to apply finalized FireFly config. Since the peering relationship was never actually saved anywhere, that restart silently wipes it. From then on the nodes are back to relying on mDNS, which is unreliable in CI - so every run was a coin flip depending on whether FireFly's first broadcast happened to land before that restart.

Fix: `POST /api/v0/config?arg=Peering.Peers&arg=<json>` instead - the same endpoint the `ipfs config` CLI command uses under the hood. Verified this persists to disk and survives a full container restart, with both nodes reconnecting automatically within ~30s.

**2. Even genuinely peered, content fetches can still hang.**

This is a long-standing upstream Kubo/bitswap bug: [ipfs/kubo#8346](https://github.com/ipfs/kubo/issues/8346), filed 2021 against `go-ipfs 0.9.1`, still open and unaddressed (labeled `need/analysis`, no maintainer activity since 2021). In a small private network, bitswap finds a provider via the DHT but never sends it a `WANT` message if the swarm connection to that peer already existed - so it looks connected, `ipfs routing findprovs` correctly identifies the provider, but `ipfs cat`/the gateway just hangs.

Reproduced directly: with `Routing.Type: dht`, `ipfs bitswap stat` showed `partners [0]` on both nodes despite `ipfs swarm peers` showing an active, bitswap-protocol-negotiated connection - even right after a fresh, verified-persisted peering + restart.

Fix: set `Routing.Type: none` instead of `dht`. With no DHT to depend on, bitswap has no choice but to broadcast wants directly to its connected peers, which is all a small private swarm actually needs - there's no "crowd" to search when you already know and are directly connected to the only other member. Verified 5/5 sequential cross-node `ipfs cat` calls plus the HTTP gateway path all succeed reliably with this change, versus 0/many succeeding with `dht`.

## Test plan
- [x] Fresh 2-member private-mode stack: `Peering.Peers` persists and survives a full manual container restart, verified via `ipfs config Peering.Peers` before/after
- [x] 5/5 sequential cross-node `ipfs cat` calls succeed with `Routing.Type: none` (0/many succeeded with `dht`, reproduced repeatedly)
- [x] HTTP gateway cross-node fetch succeeds
- [x] `go build ./...` passes
- [x] CI Build/E2E